### PR TITLE
Move babel to dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,8428 @@
+{
+	"name": "@natlibfi/marc-record-serializers",
+	"version": "5.0.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@babel/cli": {
+			"version": "7.7.7",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/cli/-/cli-7.7.7.tgz",
+			"integrity": "sha1-VoSay/gdGpcN09GzCXyOv12j9TQ=",
+			"dev": true,
+			"requires": {
+				"chokidar": "^2.1.8",
+				"commander": "^4.0.1",
+				"convert-source-map": "^1.1.0",
+				"fs-readdir-recursive": "^1.1.0",
+				"glob": "^7.0.0",
+				"lodash": "^4.17.13",
+				"make-dir": "^2.1.0",
+				"slash": "^2.0.0",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/code-frame": {
+			"version": "7.5.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/code-frame/-/code-frame-7.5.5.tgz",
+			"integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/core": {
+			"version": "7.7.7",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/core/-/core-7.7.7.tgz",
+			"integrity": "sha1-7hVdLhIwC8wM/2qK1G8q9QY4A+k=",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.5.5",
+				"@babel/generator": "^7.7.7",
+				"@babel/helpers": "^7.7.4",
+				"@babel/parser": "^7.7.7",
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.13",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.7.7",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/generator/-/generator-7.7.7.tgz",
+			"integrity": "sha1-hZrHM8RMdBSOGnKYCmTshLhfT0U=",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.7.4",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.13",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
+			"integrity": "sha1-uz+vHnS3S9VH6Gfkj1UfprCYts4=",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-builder-binary-assignment-operator-visitor": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.4.tgz",
+			"integrity": "sha1-X3PysoWA4iS1ub0DFGpAFdYhf18=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-explode-assignable-expression": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-call-delegate": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-call-delegate/-/helper-call-delegate-7.7.4.tgz",
+			"integrity": "sha1-YhuD5ZZyK1DABm+dw30yMuRhuAE=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-create-regexp-features-plugin": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
+			"integrity": "sha1-bVdiNZ/TT02hUA5M/5lVtSmar1k=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-regex": "^7.4.4",
+				"regexpu-core": "^4.6.0"
+			}
+		},
+		"@babel/helper-define-map": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-define-map/-/helper-define-map-7.7.4.tgz",
+			"integrity": "sha1-KEG/kuuL2ckGhRVG/mudReFi8XY=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/types": "^7.7.4",
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/helper-explode-assignable-expression": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
+			"integrity": "sha1-+nAIeOAI2F3FG6Q+n7g1zd/gXIQ=",
+			"dev": true,
+			"requires": {
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+			"integrity": "sha1-q24EHnE11DbY8KPsoV3ltno0Gi4=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+			"integrity": "sha1-y0Y0jS+ICOYy8KsEgXITDmNgBfA=",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.4.tgz",
+			"integrity": "sha1-YSOE49gj/fqvn84xVQ/l1NsPPRI=",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
+			"integrity": "sha1-NWQ44lad9zIagyZkTUt5DSEiy3Q=",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
+			"integrity": "sha1-5aklKfiIi/MZpjdqv70c68SRrZE=",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.7.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.7.5.tgz",
+			"integrity": "sha1-0ETaf/2R7JZ9slzWdI9wS2skSDU=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.7.4",
+				"@babel/helper-simple-access": "^7.7.4",
+				"@babel/helper-split-export-declaration": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/types": "^7.7.4",
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
+			"integrity": "sha1-A0rzE3DSmVJCqk30AsO3eUstzfI=",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha1-u7P77phmHFaQNCN8wDlnupm08lA=",
+			"dev": true
+		},
+		"@babel/helper-regex": {
+			"version": "7.5.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+			"integrity": "sha1-CqaCT3EAouDonBUnwjk2wVLKs1E=",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/helper-remap-async-to-generator": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
+			"integrity": "sha1-xowkBzUNmvDgYe1nJq+0//FtAjQ=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.7.4",
+				"@babel/helper-wrap-function": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
+			"integrity": "sha1-PIgaamp1cSdactguYQcSbsnizdI=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.7.4",
+				"@babel/helper-optimise-call-expression": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz",
+			"integrity": "sha1-oWmgrbG19BjPwZ8iWGsuv1ipopQ=",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+			"integrity": "sha1-Vykq9gRDxKNiLPdAQN3Cjmgzb9g=",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-wrap-function": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
+			"integrity": "sha1-N6t/7VFQ4i2dcmboMAcsDN2Lqs4=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/helpers/-/helpers-7.7.4.tgz",
+			"integrity": "sha1-YsIVuebHEtrcFamg3Kt2ySqUAwI=",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.5.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/highlight/-/highlight-7.5.0.tgz",
+			"integrity": "sha1-VtETEr2SSPphlZHQJHK+boyzJUA=",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/parser": {
+			"version": "7.7.7",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/parser/-/parser-7.7.7.tgz",
+			"integrity": "sha1-G4hllUGc+S2BExbVtxWlP/OLSTc=",
+			"dev": true
+		},
+		"@babel/plugin-proposal-async-generator-functions": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
+			"integrity": "sha1-A1HFrAqeknhF//1bgq9HaUe3zm0=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.7.4",
+				"@babel/plugin-syntax-async-generators": "^7.7.4"
+			}
+		},
+		"@babel/plugin-proposal-dynamic-import": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz",
+			"integrity": "sha1-3eZKfxJ2kXWMv+1s9w3g+lh51S0=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-dynamic-import": "^7.7.4"
+			}
+		},
+		"@babel/plugin-proposal-json-strings": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz",
+			"integrity": "sha1-dwCmv9p3HY3IGXMknqxBbGtMaX0=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-json-strings": "^7.7.4"
+			}
+		},
+		"@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.7.7",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.7.tgz",
+			"integrity": "sha1-nycHUASrmb4IxcG9ZTophYE8s3A=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.7.4"
+			}
+		},
+		"@babel/plugin-proposal-optional-catch-binding": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
+			"integrity": "sha1-7CHorrCexnEbwKOcpJUgq+4d43k=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+			}
+		},
+		"@babel/plugin-proposal-unicode-property-regex": {
+			"version": "7.7.7",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.7.tgz",
+			"integrity": "sha1-Qz+p2sZPlTwSV4spYz9Fa2iDHE4=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
+			"integrity": "sha1-MxqvMQoQyAxEpmsji25JEyvTyIk=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-dynamic-import": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz",
+			"integrity": "sha1-Kco7RBWr/kpew4HpA4Yq0aVMOuw=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-json-strings": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz",
+			"integrity": "sha1-huY/fS4i+eJxKaxOg+qYmjguhsw=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
+			"integrity": "sha1-R88iDRnW0NexVDBHAfRo/BzG/0Y=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
+			"integrity": "sha1-o+OPWfS2IzhntKktyw7gWywzSqY=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.4.tgz",
+			"integrity": "sha1-vX2Pp7n+55OjbkAn/W3RqjL5Rto=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-arrow-functions": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz",
+			"integrity": "sha1-djCb1Xit3YruOzedgJyAIwWpihI=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
+			"integrity": "sha1-aUy+rm1hOjTvApJxP6QvtFxEcLo=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.7.4",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-remap-async-to-generator": "^7.7.4"
+			}
+		},
+		"@babel/plugin-transform-block-scoped-functions": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
+			"integrity": "sha1-0NnVwmnHjq6nYies4hS40B5Ng3s=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-block-scoping": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz",
+			"integrity": "sha1-IAqtDc1ruANy+U2eYo6gYsWL8iQ=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/plugin-transform-classes": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.4.tgz",
+			"integrity": "sha1-ySwUvgoTmeFd9yZnBnqPUQyUAOw=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.7.4",
+				"@babel/helper-define-map": "^7.7.4",
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/helper-optimise-call-expression": "^7.7.4",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.7.4",
+				"@babel/helper-split-export-declaration": "^7.7.4",
+				"globals": "^11.1.0"
+			}
+		},
+		"@babel/plugin-transform-computed-properties": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.7.4.tgz",
+			"integrity": "sha1-6FbBYo0yOP/hLWaOtCVZ95qBkQ0=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-destructuring": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.7.4.tgz",
+			"integrity": "sha1-K3E3KeUFShE1CXtqZ9obb+h4kmc=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-dotall-regex": {
+			"version": "7.7.7",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.7.tgz",
+			"integrity": "sha1-PpcT8bafM56H+nlrCX1z3tFrk3s=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-duplicate-keys": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz",
+			"integrity": "sha1-PSFzGkLj9ZinODUpndAWnDuQrJE=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-exponentiation-operator": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz",
+			"integrity": "sha1-3TDAGR46G6GbzH44m9/dwHKdXbk=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.7.4",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-for-of": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz",
+			"integrity": "sha1-JIgA46XlB7HxA9i0ypmOd8Y5Mrw=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-function-name": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.4.tgz",
+			"integrity": "sha1-dabTMD1Q22OP+LU4XRJFHIZQJbE=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-literals": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.7.4.tgz",
+			"integrity": "sha1-J/6H0rUBeipaNNHEGmufamJiZD4=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-member-expression-literals": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.7.4.tgz",
+			"integrity": "sha1-ruEn8vMzn8NM5eMFXX/796om8Zo=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-modules-amd": {
+			"version": "7.7.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.5.tgz",
+			"integrity": "sha1-OeD7cXIktZR1swZAK7ju2rAecpw=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.7.5",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
+			}
+		},
+		"@babel/plugin-transform-modules-commonjs": {
+			"version": "7.7.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.5.tgz",
+			"integrity": "sha1-HSf16wvPdUPndJUOWy+nguY3s0U=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.7.5",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-simple-access": "^7.7.4",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
+			}
+		},
+		"@babel/plugin-transform-modules-systemjs": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz",
+			"integrity": "sha1-zZgVIznT52Pf6Di31Cc+2vUguzA=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.7.4",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
+			}
+		},
+		"@babel/plugin-transform-modules-umd": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz",
+			"integrity": "sha1-ECfDVaEY3gqun+4ArXgTxYTZBh8=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.7.4",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.4.tgz",
+			"integrity": "sha1-+zvMTuQZjnOFgFAHNz1rb0LJgiA=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.7.4"
+			}
+		},
+		"@babel/plugin-transform-new-target": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz",
+			"integrity": "sha1-SgdT0tYGOUN74HtZKp5Y7gByAWc=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-object-super": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
+			"integrity": "sha1-SEiJN6LVhsAUhFG/Ua+dfdpWcmI=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.7.4"
+			}
+		},
+		"@babel/plugin-transform-parameters": {
+			"version": "7.7.7",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.7.tgz",
+			"integrity": "sha1-eohLJGAWTcXxlPZoMyc2WEx2AAc=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-call-delegate": "^7.7.4",
+				"@babel/helper-get-function-arity": "^7.7.4",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.7.4.tgz",
+			"integrity": "sha1-I4jWUF74myZhA/RQ+RZ+a9c/mMI=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-regenerator": {
+			"version": "7.7.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.5.tgz",
+			"integrity": "sha1-OodX7hongPOQ6J8kYGXs9Zwm/Ok=",
+			"dev": true,
+			"requires": {
+				"regenerator-transform": "^0.14.0"
+			}
+		},
+		"@babel/plugin-transform-reserved-words": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.7.4.tgz",
+			"integrity": "sha1-anzxI60XW7XGmuyPbwdwOH7T8es=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.7.4.tgz",
+			"integrity": "sha1-dKCpsvbWemhMb7/V8EWOt7qZiR4=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-spread": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.7.4.tgz",
+			"integrity": "sha1-qmc7NW/mt+cNabbjOhf+9kEAhXg=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-sticky-regex": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.7.4.tgz",
+			"integrity": "sha1-/7aMBQkMMHMgdrEoXcFAG0BKEjw=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-regex": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-template-literals": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz",
+			"integrity": "sha1-HrZBFzbdP+h9vSDMZmjlEhwX1gQ=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.7.4",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-typeof-symbol": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz",
+			"integrity": "sha1-MXRiYhTy1t4yKILkmKOOg3GyFA4=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.4.tgz",
+			"integrity": "sha1-o8D2WxF8TIHFtkhPKl57lTRrg64=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/preset-env": {
+			"version": "7.7.7",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/preset-env/-/preset-env-7.7.7.tgz",
+			"integrity": "sha1-wpQWe5HlPn422CDpQ+zo0Mf+Rqw=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.7.4",
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-proposal-async-generator-functions": "^7.7.4",
+				"@babel/plugin-proposal-dynamic-import": "^7.7.4",
+				"@babel/plugin-proposal-json-strings": "^7.7.4",
+				"@babel/plugin-proposal-object-rest-spread": "^7.7.7",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.7.7",
+				"@babel/plugin-syntax-async-generators": "^7.7.4",
+				"@babel/plugin-syntax-dynamic-import": "^7.7.4",
+				"@babel/plugin-syntax-json-strings": "^7.7.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.7.4",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.7.4",
+				"@babel/plugin-syntax-top-level-await": "^7.7.4",
+				"@babel/plugin-transform-arrow-functions": "^7.7.4",
+				"@babel/plugin-transform-async-to-generator": "^7.7.4",
+				"@babel/plugin-transform-block-scoped-functions": "^7.7.4",
+				"@babel/plugin-transform-block-scoping": "^7.7.4",
+				"@babel/plugin-transform-classes": "^7.7.4",
+				"@babel/plugin-transform-computed-properties": "^7.7.4",
+				"@babel/plugin-transform-destructuring": "^7.7.4",
+				"@babel/plugin-transform-dotall-regex": "^7.7.7",
+				"@babel/plugin-transform-duplicate-keys": "^7.7.4",
+				"@babel/plugin-transform-exponentiation-operator": "^7.7.4",
+				"@babel/plugin-transform-for-of": "^7.7.4",
+				"@babel/plugin-transform-function-name": "^7.7.4",
+				"@babel/plugin-transform-literals": "^7.7.4",
+				"@babel/plugin-transform-member-expression-literals": "^7.7.4",
+				"@babel/plugin-transform-modules-amd": "^7.7.5",
+				"@babel/plugin-transform-modules-commonjs": "^7.7.5",
+				"@babel/plugin-transform-modules-systemjs": "^7.7.4",
+				"@babel/plugin-transform-modules-umd": "^7.7.4",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
+				"@babel/plugin-transform-new-target": "^7.7.4",
+				"@babel/plugin-transform-object-super": "^7.7.4",
+				"@babel/plugin-transform-parameters": "^7.7.7",
+				"@babel/plugin-transform-property-literals": "^7.7.4",
+				"@babel/plugin-transform-regenerator": "^7.7.5",
+				"@babel/plugin-transform-reserved-words": "^7.7.4",
+				"@babel/plugin-transform-shorthand-properties": "^7.7.4",
+				"@babel/plugin-transform-spread": "^7.7.4",
+				"@babel/plugin-transform-sticky-regex": "^7.7.4",
+				"@babel/plugin-transform-template-literals": "^7.7.4",
+				"@babel/plugin-transform-typeof-symbol": "^7.7.4",
+				"@babel/plugin-transform-unicode-regex": "^7.7.4",
+				"@babel/types": "^7.7.4",
+				"browserslist": "^4.6.0",
+				"core-js-compat": "^3.6.0",
+				"invariant": "^2.2.2",
+				"js-levenshtein": "^1.1.3",
+				"semver": "^5.5.0"
+			}
+		},
+		"@babel/register": {
+			"version": "7.7.7",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/register/-/register-7.7.7.tgz",
+			"integrity": "sha1-RpEMTRkmucYJZCGyPR+eFZwdzuE=",
+			"dev": true,
+			"requires": {
+				"find-cache-dir": "^2.0.0",
+				"lodash": "^4.17.13",
+				"make-dir": "^2.1.0",
+				"pirates": "^4.0.0",
+				"source-map-support": "^0.5.16"
+			}
+		},
+		"@babel/template": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/template/-/template-7.7.4.tgz",
+			"integrity": "sha1-Qop9nuz/4n3qwKmOI7+ONnXSp3s=",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/traverse/-/traverse-7.7.4.tgz",
+			"integrity": "sha1-nB58YPtnn+T8+qQlAIMzM8IFhVg=",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.5.5",
+				"@babel/generator": "^7.7.4",
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/helper-split-export-declaration": "^7.7.4",
+				"@babel/parser": "^7.7.4",
+				"@babel/types": "^7.7.4",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.13"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@babel/types/-/types-7.7.4.tgz",
+			"integrity": "sha1-UWVw1TnkTd8wjAdWnCWP+U/ekZM=",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.13",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@natlibfi/marc-record": {
+			"version": "4.0.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@natlibfi/marc-record/-/marc-record-4.0.4.tgz",
+			"integrity": "sha1-9mBcqFN/xk8oBZR8ceIHVVZDkOI=",
+			"requires": {
+				"jsonschema": "^1.2.4"
+			}
+		},
+		"@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA="
+		},
+		"acorn": {
+			"version": "7.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/acorn/-/acorn-7.1.0.tgz",
+			"integrity": "sha1-lJ028sKSU12mAig1hsJHfFfrLWw=",
+			"dev": true
+		},
+		"acorn-jsx": {
+			"version": "5.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+			"integrity": "sha1-KUrbcbVzmLBoABXwo4xWPuHbU4Q=",
+			"dev": true
+		},
+		"ajv": {
+			"version": "6.10.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ajv/-/ajv-6.10.2.tgz",
+			"integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "^2.0.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"ansi-align": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-align/-/ansi-align-2.0.0.tgz",
+			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+			"dev": true,
+			"requires": {
+				"string-width": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"ansi-colors": {
+			"version": "3.2.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-colors/-/ansi-colors-3.2.3.tgz",
+			"integrity": "sha1-V9NbhoboUeLMBMQD8cACA5dqGBM=",
+			"dev": true
+		},
+		"ansi-escapes": {
+			"version": "4.3.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+			"integrity": "sha1-pM4rM9ayFLeVDYWVwhLxKsnMVp0=",
+			"dev": true,
+			"requires": {
+				"type-fest": "^0.8.1"
+			}
+		},
+		"ansi-regex": {
+			"version": "5.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+			"integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
+		},
+		"ansi-styles": {
+			"version": "4.2.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
+			"integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+			"requires": {
+				"@types/color-name": "^1.1.1",
+				"color-convert": "^2.0.1"
+			}
+		},
+		"anymatch": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
+			},
+			"dependencies": {
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				}
+			}
+		},
+		"append-transform": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/append-transform/-/append-transform-1.0.0.tgz",
+			"integrity": "sha1-BGpSrlgqIovXL1is++KWfGeHWas=",
+			"dev": true,
+			"requires": {
+				"default-require-extensions": "^2.0.0"
+			}
+		},
+		"archy": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/archy/-/archy-1.0.0.tgz",
+			"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+			"dev": true
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"arr-diff": {
+			"version": "4.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"dev": true,
+			"optional": true
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+			"dev": true,
+			"optional": true
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true,
+			"optional": true
+		},
+		"array-find-index": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/array-find-index/-/array-find-index-1.0.2.tgz",
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+			"dev": true
+		},
+		"array-includes": {
+			"version": "3.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/array-includes/-/array-includes-3.1.1.tgz",
+			"integrity": "sha1-zdZ+aFK9+cEhVGB4ZzIlXtJFk0g=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0",
+				"is-string": "^1.0.5"
+			}
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
+			"requires": {
+				"array-uniq": "^1.0.1"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
+		},
+		"array-unique": {
+			"version": "0.3.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"dev": true,
+			"optional": true
+		},
+		"array.prototype.flat": {
+			"version": "1.2.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+			"integrity": "sha1-DegrQmsDGNv9uUAInjiwQ9N/bHs=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
+			}
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+			"dev": true
+		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true,
+			"optional": true
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
+			"dev": true
+		},
+		"async-each": {
+			"version": "1.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
+			"dev": true,
+			"optional": true
+		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
+			"dev": true,
+			"optional": true
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
+		},
+		"babel-eslint": {
+			"version": "10.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/babel-eslint/-/babel-eslint-10.0.3.tgz",
+			"integrity": "sha1-gaLGab4PIF4ZRi/tJILTPkaHqIo=",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
+				"eslint-visitor-keys": "^1.0.0",
+				"resolve": "^1.12.0"
+			}
+		},
+		"babel-messages": {
+			"version": "6.23.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/babel-messages/-/babel-messages-6.23.0.tgz",
+			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0"
+			}
+		},
+		"babel-plugin-dynamic-import-node": {
+			"version": "2.3.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+			"integrity": "sha1-8A9Qe9qjw+P/bn5emNkKesq5b38=",
+			"dev": true,
+			"requires": {
+				"object.assign": "^4.1.0"
+			}
+		},
+		"babel-plugin-istanbul": {
+			"version": "5.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+			"integrity": "sha1-30reg9iXqS3wacTZolzyZxKTyFQ=",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"find-up": "^3.0.0",
+				"istanbul-lib-instrument": "^3.3.0",
+				"test-exclude": "^5.2.3"
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
+			"requires": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
+			}
+		},
+		"babel-traverse": {
+			"version": "6.26.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
+			},
+			"dependencies": {
+				"globals": {
+					"version": "9.18.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/globals/-/globals-9.18.0.tgz",
+					"integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+					"dev": true
+				}
+			}
+		},
+		"babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			},
+			"dependencies": {
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+					"dev": true
+				}
+			}
+		},
+		"babylon": {
+			"version": "6.18.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
+			"dev": true
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/base/-/base-0.11.2.tgz",
+			"integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"binary-extensions": {
+			"version": "1.13.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
+			"dev": true,
+			"optional": true
+		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"boxen": {
+			"version": "1.3.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/boxen/-/boxen-1.3.0.tgz",
+			"integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
+			"dev": true,
+			"requires": {
+				"ansi-align": "^2.0.0",
+				"camelcase": "^4.0.0",
+				"chalk": "^2.0.1",
+				"cli-boxes": "^1.0.0",
+				"string-width": "^2.0.0",
+				"term-size": "^1.2.0",
+				"widest-line": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "2.3.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+			"dev": true
+		},
+		"browserslist": {
+			"version": "4.8.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/browserslist/-/browserslist-4.8.3.tgz",
+			"integrity": "sha1-ZYAvzXcXfIeOAV8OMYnyxPYnukQ=",
+			"dev": true,
+			"requires": {
+				"caniuse-lite": "^1.0.30001017",
+				"electron-to-chromium": "^1.3.322",
+				"node-releases": "^1.1.44"
+			}
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+			"dev": true
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			}
+		},
+		"caching-transform": {
+			"version": "3.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/caching-transform/-/caching-transform-3.0.2.tgz",
+			"integrity": "sha1-YB1GuR7Kh2h6KB5xzvmXkbDvynA=",
+			"dev": true,
+			"requires": {
+				"hasha": "^3.0.0",
+				"make-dir": "^2.0.0",
+				"package-hash": "^3.0.0",
+				"write-file-atomic": "^2.4.2"
+			}
+		},
+		"callsite": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/callsite/-/callsite-1.0.0.tgz",
+			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+			"dev": true
+		},
+		"callsite-record": {
+			"version": "3.2.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/callsite-record/-/callsite-record-3.2.2.tgz",
+			"integrity": "sha1-mgOQZC5D/ou4I5ReUUZPafQWQ94=",
+			"dev": true,
+			"requires": {
+				"callsite": "^1.0.0",
+				"chalk": "^1.1.1",
+				"error-stack-parser": "^1.3.3",
+				"highlight-es": "^1.0.0",
+				"lodash": "4.6.1 || ^4.16.1",
+				"pinkie-promise": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
+		},
+		"callsites": {
+			"version": "3.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
+		},
+		"camelcase-keys": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+			"dev": true,
+			"requires": {
+				"camelcase": "^2.0.0",
+				"map-obj": "^1.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "2.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/camelcase/-/camelcase-2.1.1.tgz",
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+					"dev": true
+				}
+			}
+		},
+		"caniuse-lite": {
+			"version": "1.0.30001020",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001020.tgz",
+			"integrity": "sha1-PwTBc3UA/9p4vpvrC1weIHDhWSY=",
+			"dev": true
+		},
+		"capture-stack-trace": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+			"integrity": "sha1-psC74fOPOqC5Ijjstv9Cw0TUE10=",
+			"dev": true
+		},
+		"chai": {
+			"version": "4.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chai/-/chai-4.2.0.tgz",
+			"integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
+			"dev": true,
+			"requires": {
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.2",
+				"deep-eql": "^3.0.1",
+				"get-func-name": "^2.0.0",
+				"pathval": "^1.1.0",
+				"type-detect": "^4.0.5"
+			}
+		},
+		"chalk": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chalk/-/chalk-3.0.0.tgz",
+			"integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+			"requires": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			}
+		},
+		"chardet": {
+			"version": "0.7.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
+			"dev": true
+		},
+		"check-error": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+			"dev": true
+		},
+		"chokidar": {
+			"version": "2.1.8",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chokidar/-/chokidar-2.1.8.tgz",
+			"integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"anymatch": "^2.0.0",
+				"async-each": "^1.0.1",
+				"braces": "^2.3.2",
+				"fsevents": "^1.2.7",
+				"glob-parent": "^3.1.0",
+				"inherits": "^2.0.3",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"normalize-path": "^3.0.0",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.2.1",
+				"upath": "^1.1.1"
+			}
+		},
+		"chokidar-cli": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chokidar-cli/-/chokidar-cli-2.1.0.tgz",
+			"integrity": "sha1-JJHfEzvWLNFFInsXRvvZTycz4bw=",
+			"dev": true,
+			"requires": {
+				"chokidar": "^3.2.3",
+				"lodash.debounce": "^4.0.8",
+				"lodash.throttle": "^4.1.1",
+				"yargs": "^13.3.0"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "3.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/anymatch/-/anymatch-3.1.1.tgz",
+					"integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
+					"dev": true,
+					"requires": {
+						"normalize-path": "^3.0.0",
+						"picomatch": "^2.0.4"
+					}
+				},
+				"binary-extensions": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/binary-extensions/-/binary-extensions-2.0.0.tgz",
+					"integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
+					"dev": true
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chokidar": {
+					"version": "3.3.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chokidar/-/chokidar-3.3.1.tgz",
+					"integrity": "sha1-yE5bPRjZpNd1WP70ZrG/FrvrNFA=",
+					"dev": true,
+					"requires": {
+						"anymatch": "~3.1.1",
+						"braces": "~3.0.2",
+						"fsevents": "~2.1.2",
+						"glob-parent": "~5.1.0",
+						"is-binary-path": "~2.1.0",
+						"is-glob": "~4.0.1",
+						"normalize-path": "~3.0.0",
+						"readdirp": "~3.3.0"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"fsevents": {
+					"version": "2.1.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha1-TAofs0vGjlQ7S4Kp7Dkr+9qECAU=",
+					"dev": true,
+					"optional": true
+				},
+				"glob-parent": {
+					"version": "5.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha1-X0wdHnSNMM1zrSlEs1d6gbCB6MI=",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"is-binary-path": {
+					"version": "2.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
+					"integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+					"dev": true,
+					"requires": {
+						"binary-extensions": "^2.0.0"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+					"dev": true
+				},
+				"readdirp": {
+					"version": "3.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/readdirp/-/readdirp-3.3.0.tgz",
+					"integrity": "sha1-mERY0ToeQuLp9YQbEp4WLzaa/xc=",
+					"dev": true,
+					"requires": {
+						"picomatch": "^2.0.7"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"yargs": {
+					"version": "13.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yargs/-/yargs-13.3.0.tgz",
+					"integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha1-0mBYUyqgbTZf4JH2ofwGsvfl7KA=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"ci-info": {
+			"version": "1.6.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ci-info/-/ci-info-1.6.0.tgz",
+			"integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc=",
+			"dev": true
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"cli-boxes": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
+			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+			"dev": true
+		},
+		"cli-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
+			"requires": {
+				"restore-cursor": "^3.1.0"
+			}
+		},
+		"cli-spinners": {
+			"version": "2.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cli-spinners/-/cli-spinners-2.2.0.tgz",
+			"integrity": "sha1-6LmI2SBsaSMC2O6DTnqFwBRNj3c="
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
+		},
+		"cliui": {
+			"version": "5.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cliui/-/cliui-5.0.0.tgz",
+			"integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+			"requires": {
+				"string-width": "^3.1.0",
+				"strip-ansi": "^5.2.0",
+				"wrap-ansi": "^5.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
+			}
+		},
+		"clone": {
+			"version": "1.0.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
+		},
+		"color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+			"requires": {
+				"color-name": "~1.1.4"
+			}
+		},
+		"color-name": {
+			"version": "1.1.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+		},
+		"commander": {
+			"version": "4.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/commander/-/commander-4.1.0.tgz",
+			"integrity": "sha1-VFmDoGA/5CW8Zy1myePInEISGoM=",
+			"dev": true
+		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
+		},
+		"component-emitter": {
+			"version": "1.3.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
+			"dev": true,
+			"optional": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"configstore": {
+			"version": "3.1.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/configstore/-/configstore-3.1.2.tgz",
+			"integrity": "sha1-xvJd767vJt8S3TNBSwAf6BpUP48=",
+			"dev": true,
+			"requires": {
+				"dot-prop": "^4.1.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"unique-string": "^1.0.0",
+				"write-file-atomic": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "1.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/make-dir/-/make-dir-1.3.0.tgz",
+					"integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
+			}
+		},
+		"contains-path": {
+			"version": "0.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/contains-path/-/contains-path-0.1.0.tgz",
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"dev": true
+		},
+		"convert-source-map": {
+			"version": "1.7.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true,
+			"optional": true
+		},
+		"core-js": {
+			"version": "2.6.11",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/core-js/-/core-js-2.6.11.tgz",
+			"integrity": "sha1-OIMUafmSK97Y7iHJ3EaYXgOZMIw=",
+			"dev": true
+		},
+		"core-js-compat": {
+			"version": "3.6.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/core-js-compat/-/core-js-compat-3.6.2.tgz",
+			"integrity": "sha1-MUyouE1eccJ8GfHs2pZlAbHPHxA=",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.8.3",
+				"semver": "7.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/semver/-/semver-7.0.0.tgz",
+					"integrity": "sha1-XzyjV2HkfgWyBsba/yz4FPAxa44=",
+					"dev": true
+				}
+			}
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true,
+			"optional": true
+		},
+		"cp-file": {
+			"version": "6.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cp-file/-/cp-file-6.2.0.tgz",
+			"integrity": "sha1-QNXqSh3vKprN0HulwLAkbvc9wQ0=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^2.0.0",
+				"nested-error-stacks": "^2.0.0",
+				"pify": "^4.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"create-error-class": {
+			"version": "3.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/create-error-class/-/create-error-class-3.0.2.tgz",
+			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+			"dev": true,
+			"requires": {
+				"capture-stack-trace": "^1.0.0"
+			}
+		},
+		"cross-env": {
+			"version": "6.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cross-env/-/cross-env-6.0.3.tgz",
+			"integrity": "sha1-Qla3HkmzpAY3oM5wdopu9ccq6UE=",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.0"
+			}
+		},
+		"cross-spawn": {
+			"version": "7.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cross-spawn/-/cross-spawn-7.0.1.tgz",
+			"integrity": "sha1-CrVihuD3wk4VPQTMKqAn5DqaXRQ=",
+			"dev": true,
+			"requires": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			}
+		},
+		"cross-spawn-async": {
+			"version": "2.2.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+			"integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^4.0.0",
+				"which": "^1.2.8"
+			},
+			"dependencies": {
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/which/-/which-1.3.1.tgz",
+					"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
+		"crypto-random-string": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+			"dev": true
+		},
+		"currently-unhandled": {
+			"version": "0.4.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"dev": true,
+			"requires": {
+				"array-find-index": "^1.0.1"
+			}
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+			"dev": true,
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"dev": true,
+			"optional": true
+		},
+		"deep-eql": {
+			"version": "3.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/deep-eql/-/deep-eql-3.0.1.tgz",
+			"integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+			"dev": true,
+			"requires": {
+				"type-detect": "^4.0.0"
+			}
+		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
+			"dev": true
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"default-require-extensions": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+			"dev": true,
+			"requires": {
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"defaults": {
+			"version": "1.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/defaults/-/defaults-1.0.3.tgz",
+			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+			"requires": {
+				"clone": "^1.0.2"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+			"dev": true,
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"depcheck": {
+			"version": "0.6.11",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/depcheck/-/depcheck-0.6.11.tgz",
+			"integrity": "sha1-a2FvLPjETdz9xdfH93WbxTtHkmI=",
+			"dev": true,
+			"requires": {
+				"babel-traverse": "^6.7.3",
+				"babylon": "^6.1.21",
+				"builtin-modules": "^1.1.1",
+				"deprecate": "^1.0.0",
+				"deps-regex": "^0.1.4",
+				"js-yaml": "^3.4.2",
+				"lodash": "^4.5.1",
+				"minimatch": "^3.0.2",
+				"require-package-name": "^2.0.1",
+				"walkdir": "0.0.11",
+				"yargs": "^8.0.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://eis.jfrog.io/eis/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"dev": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						}
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"get-caller-file": {
+					"version": "1.0.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
+					"integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"dev": true,
+					"requires": {
+						"pify": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
+					}
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+							"dev": true
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"dev": true,
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://eis.jfrog.io/eis/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"dev": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						}
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+					"dev": true
+				},
+				"yargs": {
+					"version": "8.0.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yargs/-/yargs-8.0.2.tgz",
+					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"read-pkg-up": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^7.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "7.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yargs-parser/-/yargs-parser-7.0.0.tgz",
+					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
+				}
+			}
+		},
+		"deprecate": {
+			"version": "1.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/deprecate/-/deprecate-1.1.1.tgz",
+			"integrity": "sha1-RjLpgfyBXurwC+lFpANZwPi/mRM=",
+			"dev": true
+		},
+		"deps-regex": {
+			"version": "0.1.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/deps-regex/-/deps-regex-0.1.4.tgz",
+			"integrity": "sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ=",
+			"dev": true
+		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+			"dev": true
+		},
+		"doctrine": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2"
+			}
+		},
+		"dot-prop": {
+			"version": "4.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/dot-prop/-/dot-prop-4.2.0.tgz",
+			"integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
+			"dev": true,
+			"requires": {
+				"is-obj": "^1.0.0"
+			}
+		},
+		"duplexer3": {
+			"version": "0.1.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/duplexer3/-/duplexer3-0.1.4.tgz",
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+			"dev": true
+		},
+		"electron-to-chromium": {
+			"version": "1.3.330",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.3.330.tgz",
+			"integrity": "sha1-woiuuJ+iwVh5wp+BpDYjdBMjh/s=",
+			"dev": true
+		},
+		"emoji-regex": {
+			"version": "7.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY="
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"error-stack-parser": {
+			"version": "1.3.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
+			"integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
+			"dev": true,
+			"requires": {
+				"stackframe": "^0.3.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.17.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/es-abstract/-/es-abstract-1.17.0.tgz",
+			"integrity": "sha1-9CpRfQA2pVkduyxGNZHci7UDCbE=",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.2.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1",
+				"is-callable": "^1.1.5",
+				"is-regex": "^1.0.5",
+				"object-inspect": "^1.7.0",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.0",
+				"string.prototype.trimleft": "^2.1.1",
+				"string.prototype.trimright": "^2.1.1"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
+		},
+		"es6-error": {
+			"version": "4.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/es6-error/-/es6-error-4.1.1.tgz",
+			"integrity": "sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0=",
+			"dev": true
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"eslint": {
+			"version": "6.8.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/eslint/-/eslint-6.8.0.tgz",
+			"integrity": "sha1-YiYtZylzn5J1cjgkMC+yJ8jJP/s=",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"ajv": "^6.10.0",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.5",
+				"debug": "^4.0.1",
+				"doctrine": "^3.0.0",
+				"eslint-scope": "^5.0.0",
+				"eslint-utils": "^1.4.3",
+				"eslint-visitor-keys": "^1.1.0",
+				"espree": "^6.1.2",
+				"esquery": "^1.0.1",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^5.0.1",
+				"functional-red-black-tree": "^1.0.1",
+				"glob-parent": "^5.0.0",
+				"globals": "^12.1.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.0.0",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^7.0.0",
+				"is-glob": "^4.0.0",
+				"js-yaml": "^3.13.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.14",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.3",
+				"progress": "^2.0.0",
+				"regexpp": "^2.0.1",
+				"semver": "^6.1.2",
+				"strip-ansi": "^5.2.0",
+				"strip-json-comments": "^3.0.1",
+				"table": "^5.2.3",
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://eis.jfrog.io/eis/api/npm/npm/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+							"dev": true
+						}
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha1-X0wdHnSNMM1zrSlEs1d6gbCB6MI=",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"globals": {
+					"version": "12.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/globals/-/globals-12.3.0.tgz",
+					"integrity": "sha1-HlZO5cTd7SqwmLD4jyRwKjxWvhM=",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.8.1"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+					"dev": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/shebang-command/-/shebang-command-1.2.0.tgz",
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/which/-/which-1.3.1.tgz",
+					"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
+		"eslint-config-xo": {
+			"version": "0.27.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/eslint-config-xo/-/eslint-config-xo-0.27.2.tgz",
+			"integrity": "sha1-ca/z1bVVTp5bXhhT4h2neZu1Px8=",
+			"dev": true
+		},
+		"eslint-import-resolver-node": {
+			"version": "0.3.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+			"integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.9",
+				"resolve": "^1.5.0"
+			}
+		},
+		"eslint-module-utils": {
+			"version": "2.5.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/eslint-module-utils/-/eslint-module-utils-2.5.0.tgz",
+			"integrity": "sha1-zfC0DWIwMidMzSq9fmTE5STW4Zw=",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.9",
+				"pkg-dir": "^2.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.1.0"
+					}
+				}
+			}
+		},
+		"eslint-plugin-import": {
+			"version": "2.19.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/eslint-plugin-import/-/eslint-plugin-import-2.19.1.tgz",
+			"integrity": "sha1-VlThC3g50GTdDUbNG4jsITOhFEg=",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.0.3",
+				"array.prototype.flat": "^1.2.1",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.9",
+				"doctrine": "1.5.0",
+				"eslint-import-resolver-node": "^0.3.2",
+				"eslint-module-utils": "^2.4.1",
+				"has": "^1.0.3",
+				"minimatch": "^3.0.4",
+				"object.values": "^1.1.0",
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.12.0"
+			},
+			"dependencies": {
+				"doctrine": {
+					"version": "1.5.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/doctrine/-/doctrine-1.5.0.tgz",
+					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"isarray": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"dev": true,
+					"requires": {
+						"pify": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
+					}
+				}
+			}
+		},
+		"eslint-plugin-mocha": {
+			"version": "6.2.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/eslint-plugin-mocha/-/eslint-plugin-mocha-6.2.2.tgz",
+			"integrity": "sha1-bvS3i9EtdEvrCKBuggneMwmFEA0=",
+			"dev": true,
+			"requires": {
+				"ramda": "^0.26.1"
+			}
+		},
+		"eslint-scope": {
+			"version": "5.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/eslint-scope/-/eslint-scope-5.0.0.tgz",
+			"integrity": "sha1-6HyIh8c+jR7ITxylkWRcNYv8j7k=",
+			"dev": true,
+			"requires": {
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
+			}
+		},
+		"eslint-utils": {
+			"version": "1.4.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^1.1.0"
+			}
+		},
+		"eslint-visitor-keys": {
+			"version": "1.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+			"integrity": "sha1-4qgs6oT/JGrW+1f5veW0ZiFFnsI=",
+			"dev": true
+		},
+		"espree": {
+			"version": "6.1.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha1-bCcmUJMrT5HDcU5ee19eLs9HJi0=",
+			"dev": true,
+			"requires": {
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
+				"eslint-visitor-keys": "^1.1.0"
+			}
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+			"dev": true
+		},
+		"esquery": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/esquery/-/esquery-1.0.1.tgz",
+			"integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
+			"dev": true,
+			"requires": {
+				"estraverse": "^4.0.0"
+			}
+		},
+		"esrecurse": {
+			"version": "4.2.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+			"dev": true,
+			"requires": {
+				"estraverse": "^4.1.0"
+			}
+		},
+		"estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
+			"dev": true
+		},
+		"execa": {
+			"version": "0.2.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/execa/-/execa-0.2.2.tgz",
+			"integrity": "sha1-4urUcsLDGq1vc/GslW7vReEjIMs=",
+			"dev": true,
+			"requires": {
+				"cross-spawn-async": "^2.1.1",
+				"npm-run-path": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"path-key": "^1.0.0",
+				"strip-eof": "^1.0.0"
+			},
+			"dependencies": {
+				"npm-run-path": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/npm-run-path/-/npm-run-path-1.0.0.tgz",
+					"integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
+					"dev": true,
+					"requires": {
+						"path-key": "^1.0.0"
+					}
+				},
+				"path-key": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-key/-/path-key-1.0.0.tgz",
+					"integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
+					"dev": true
+				}
+			}
+		},
+		"exit-hook": {
+			"version": "1.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/exit-hook/-/exit-hook-1.1.1.tgz",
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+			"dev": true
+		},
+		"expand-brackets": {
+			"version": "2.1.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"expand-tilde": {
+			"version": "2.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/expand-tilde/-/expand-tilde-2.0.2.tgz",
+			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+			"dev": true,
+			"requires": {
+				"homedir-polyfill": "^1.0.1"
+			}
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"external-editor": {
+			"version": "3.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/external-editor/-/external-editor-3.1.0.tgz",
+			"integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
+			"dev": true,
+			"requires": {
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
+				"tmp": "^0.0.33"
+			}
+		},
+		"extglob": {
+			"version": "2.0.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"figures": {
+			"version": "3.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/figures/-/figures-3.1.0.tgz",
+			"integrity": "sha1-SxmN0H2NcVMGQoZK8tRd2eRZxOw=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			}
+		},
+		"file-entry-cache": {
+			"version": "5.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+			"integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
+			"dev": true,
+			"requires": {
+				"flat-cache": "^2.0.1"
+			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
+			"dev": true,
+			"optional": true
+		},
+		"fill-range": {
+			"version": "4.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"find-cache-dir": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+			"integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+			"dev": true,
+			"requires": {
+				"commondir": "^1.0.1",
+				"make-dir": "^2.0.0",
+				"pkg-dir": "^3.0.0"
+			}
+		},
+		"find-up": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+			"requires": {
+				"locate-path": "^3.0.0"
+			}
+		},
+		"flat": {
+			"version": "4.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/flat/-/flat-4.1.0.tgz",
+			"integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
+			"dev": true,
+			"requires": {
+				"is-buffer": "~2.0.3"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM=",
+					"dev": true
+				}
+			}
+		},
+		"flat-cache": {
+			"version": "2.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/flat-cache/-/flat-cache-2.0.1.tgz",
+			"integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
+			"dev": true,
+			"requires": {
+				"flatted": "^2.0.0",
+				"rimraf": "2.6.3",
+				"write": "1.0.3"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
+			}
+		},
+		"flatted": {
+			"version": "2.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/flatted/-/flatted-2.0.1.tgz",
+			"integrity": "sha1-aeV8qo8OrLwoHS4stFjUb9tEngg=",
+			"dev": true
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true,
+			"optional": true
+		},
+		"foreground-child": {
+			"version": "1.5.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/foreground-child/-/foreground-child-1.5.6.tgz",
+			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^4",
+				"signal-exit": "^3.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "4.0.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cross-spawn/-/cross-spawn-4.0.2.tgz",
+					"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/which/-/which-1.3.1.tgz",
+					"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"map-cache": "^0.2.2"
+			}
+		},
+		"fs-readdir-recursive": {
+			"version": "1.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+			"integrity": "sha1-4y/AMKLM7kSmtTcTCNpUvgs5fSc=",
+			"dev": true
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"fsevents": {
+			"version": "1.2.11",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/fsevents/-/fsevents-1.2.11.tgz",
+			"integrity": "sha1-Z79X9HWPAu3oj7KhcS/vTRU1i+M=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"bindings": "^1.5.0",
+				"nan": "^2.12.1",
+				"node-pre-gyp": "*"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"aproba": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"chownr": {
+					"version": "1.1.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"debug": {
+					"version": "3.2.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"deep-extend": {
+					"version": "0.6.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"fs-minipass": {
+					"version": "1.2.7",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.6.0"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"iconv-lite": {
+					"version": "0.4.24",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"ignore-walk": {
+					"version": "3.0.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minimatch": "^3.0.4"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"ini": {
+					"version": "1.3.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"minipass": {
+					"version": "2.9.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "1.3.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.9.0"
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"needle": {
+					"version": "2.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"debug": "^3.2.6",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
+					}
+				},
+				"node-pre-gyp": {
+					"version": "0.14.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.1",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.2.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4.4.2"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1",
+						"osenv": "^0.1.4"
+					}
+				},
+				"npm-bundled": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"npm-normalize-package-bin": "^1.0.1"
+					}
+				},
+				"npm-normalize-package-bin": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"npm-packlist": {
+					"version": "1.4.7",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.8",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "^0.6.0",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"sax": {
+					"version": "1.2.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"semver": {
+					"version": "5.7.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "4.4.13",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"chownr": "^1.1.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.8.6",
+						"minizlib": "^1.2.1",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.3"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"wide-align": {
+					"version": "1.1.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"string-width": "^1.0.2 || 2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"yallist": {
+					"version": "3.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+			"dev": true
+		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+			"dev": true
+		},
+		"get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
+		},
+		"get-func-name": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/get-func-name/-/get-func-name-2.0.0.tgz",
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"dev": true
+		},
+		"get-stdin": {
+			"version": "4.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/get-stdin/-/get-stdin-4.0.1.tgz",
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+			"dev": true
+		},
+		"get-stream": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/get-stream/-/get-stream-3.0.0.tgz",
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+			"dev": true
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true,
+			"optional": true
+		},
+		"giturl": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/giturl/-/giturl-1.0.1.tgz",
+			"integrity": "sha1-kmxpvaXEij2PdCVOmfgmg15qSqA=",
+			"dev": true
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
+			},
+			"dependencies": {
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				}
+			}
+		},
+		"global-dirs": {
+			"version": "0.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/global-dirs/-/global-dirs-0.1.1.tgz",
+			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"dev": true,
+			"requires": {
+				"ini": "^1.3.4"
+			}
+		},
+		"global-modules": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/global-modules/-/global-modules-1.0.0.tgz",
+			"integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
+			"dev": true,
+			"requires": {
+				"global-prefix": "^1.0.1",
+				"is-windows": "^1.0.1",
+				"resolve-dir": "^1.0.0"
+			}
+		},
+		"global-prefix": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/global-prefix/-/global-prefix-1.0.2.tgz",
+			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+			"dev": true,
+			"requires": {
+				"expand-tilde": "^2.0.2",
+				"homedir-polyfill": "^1.0.1",
+				"ini": "^1.3.4",
+				"is-windows": "^1.0.1",
+				"which": "^1.2.14"
+			},
+			"dependencies": {
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/which/-/which-1.3.1.tgz",
+					"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+			"dev": true
+		},
+		"globby": {
+			"version": "4.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/globby/-/globby-4.1.0.tgz",
+			"integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+			"dev": true,
+			"requires": {
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"glob": "^6.0.1",
+				"object-assign": "^4.0.1",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "6.0.4",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/glob/-/glob-6.0.4.tgz",
+					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+					"dev": true,
+					"requires": {
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				}
+			}
+		},
+		"got": {
+			"version": "6.7.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/got/-/got-6.7.1.tgz",
+			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+			"dev": true,
+			"requires": {
+				"create-error-class": "^3.0.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-redirect": "^1.0.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"lowercase-keys": "^1.0.0",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"unzip-response": "^2.0.1",
+				"url-parse-lax": "^1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.2.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/graceful-fs/-/graceful-fs-4.2.3.tgz",
+			"integrity": "sha1-ShL/G2A3bvCYYsIJPt2Qgyi+hCM=",
+			"dev": true
+		},
+		"growl": {
+			"version": "1.10.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+			"dev": true
+		},
+		"handlebars": {
+			"version": "4.6.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/handlebars/-/handlebars-4.6.0.tgz",
+			"integrity": "sha1-M69sPtqTDXqST12PHG2O3DGAUS4=",
+			"dev": true,
+			"requires": {
+				"neo-async": "^2.6.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"dev": true
+				}
+			}
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has/-/has-1.0.3.tgz",
+			"integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				}
+			}
+		},
+		"has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+		},
+		"has-symbols": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-symbols/-/has-symbols-1.0.1.tgz",
+			"integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
+			"dev": true
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"hasha": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/hasha/-/hasha-3.0.0.tgz",
+			"integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+			"dev": true,
+			"requires": {
+				"is-stream": "^1.0.1"
+			}
+		},
+		"he": {
+			"version": "1.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/he/-/he-1.2.0.tgz",
+			"integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
+			"dev": true
+		},
+		"highlight-es": {
+			"version": "1.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/highlight-es/-/highlight-es-1.0.3.tgz",
+			"integrity": "sha1-EqvDAKJ+aG9vGAEBNOOlxtL+aTA=",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.0",
+				"is-es2016-keyword": "^1.0.0",
+				"js-tokens": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"homedir-polyfill": {
+			"version": "1.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha1-dDKYzvTlrz4ZQWH7rcwhUdOgWOg=",
+			"dev": true,
+			"requires": {
+				"parse-passwd": "^1.0.0"
+			}
+		},
+		"hosted-git-info": {
+			"version": "2.8.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+			"integrity": "sha1-dZz88sTRVq3lmwst+r3cQqa5xww=",
+			"dev": true
+		},
+		"iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
+		"ignore": {
+			"version": "4.0.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+			"dev": true
+		},
+		"import-fresh": {
+			"version": "3.2.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/import-fresh/-/import-fresh-3.2.1.tgz",
+			"integrity": "sha1-Yz/2GFBueTr1rJG/SLcmd+FcvmY=",
+			"dev": true,
+			"requires": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			}
+		},
+		"import-lazy": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/import-lazy/-/import-lazy-2.1.0.tgz",
+			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+			"dev": true
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"indent-string": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/indent-string/-/indent-string-2.1.0.tgz",
+			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+			"dev": true,
+			"requires": {
+				"repeating": "^2.0.0"
+			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+			"dev": true
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+			"dev": true
+		},
+		"inquirer": {
+			"version": "7.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/inquirer/-/inquirer-7.0.3.tgz",
+			"integrity": "sha1-+bTNLf9Yufc+jUN1lDas4VvtRWc=",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^2.4.2",
+				"cli-cursor": "^3.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^3.0.3",
+				"figures": "^3.0.0",
+				"lodash": "^4.17.15",
+				"mute-stream": "0.0.8",
+				"run-async": "^2.2.0",
+				"rxjs": "^6.5.3",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^5.1.0",
+				"through": "^2.3.6"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "6.0.0",
+							"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+							"integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^5.0.0"
+							}
+						}
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+							"integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+							"dev": true
+						}
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"invert-kv": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/invert-kv/-/invert-kv-1.0.0.tgz",
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
+		},
+		"is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"binary-extensions": "^1.0.0"
+			}
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+			"dev": true,
+			"optional": true
+		},
+		"is-callable": {
+			"version": "1.1.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-callable/-/is-callable-1.1.5.tgz",
+			"integrity": "sha1-9+RrWWiQRW23Tn9ul2yzJz0G+qs=",
+			"dev": true
+		},
+		"is-ci": {
+			"version": "1.2.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-ci/-/is-ci-1.2.1.tgz",
+			"integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
+			"dev": true,
+			"requires": {
+				"ci-info": "^1.5.0"
+			}
+		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-date-object/-/is-date-object-1.0.2.tgz",
+			"integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
+			"dev": true
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"is-es2016-keyword": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-es2016-keyword/-/is-es2016-keyword-1.0.0.tgz",
+			"integrity": "sha1-9uVOEQxeT40mXmnS7Q6vjPX0dxg=",
+			"dev": true
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true,
+			"optional": true
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
+		"is-finite": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-finite/-/is-finite-1.0.2.tgz",
+			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
+			"requires": {
+				"number-is-nan": "^1.0.0"
+			}
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+		},
+		"is-glob": {
+			"version": "4.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
+		},
+		"is-installed-globally": {
+			"version": "0.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+			"dev": true,
+			"requires": {
+				"global-dirs": "^0.1.0",
+				"is-path-inside": "^1.0.0"
+			}
+		},
+		"is-interactive": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-interactive/-/is-interactive-1.0.0.tgz",
+			"integrity": "sha1-zqbmrlyHCnsKAAQHC3tYfgJSkS4="
+		},
+		"is-npm": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-npm/-/is-npm-1.0.0.tgz",
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+			"dev": true
+		},
+		"is-number": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"dev": true
+		},
+		"is-path-inside": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
+			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
+			"requires": {
+				"path-is-inside": "^1.0.1"
+			}
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
+		},
+		"is-redirect": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-redirect/-/is-redirect-1.0.0.tgz",
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+			"dev": true
+		},
+		"is-regex": {
+			"version": "1.0.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-regex/-/is-regex-1.0.5.tgz",
+			"integrity": "sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
+		"is-retry-allowed": {
+			"version": "1.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+			"integrity": "sha1-13hIi9CkZmo76KFIK58rqv7eqLQ=",
+			"dev": true
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
+		},
+		"is-string": {
+			"version": "1.0.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-string/-/is-string-1.0.5.tgz",
+			"integrity": "sha1-QEk+0ZjvP/R3uMf5L2ROyCpc06Y=",
+			"dev": true
+		},
+		"is-symbol": {
+			"version": "1.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-symbol/-/is-symbol-1.0.3.tgz",
+			"integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true,
+			"optional": true
+		},
+		"istanbul-lib-coverage": {
+			"version": "2.0.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+			"integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
+			"dev": true
+		},
+		"istanbul-lib-hook": {
+			"version": "2.0.7",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+			"integrity": "sha1-yVaV84PU+PYN8fBCUqlVDhW1sTM=",
+			"dev": true,
+			"requires": {
+				"append-transform": "^1.0.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "3.3.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+			"integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
+			"dev": true,
+			"requires": {
+				"@babel/generator": "^7.4.0",
+				"@babel/parser": "^7.4.3",
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.3",
+				"@babel/types": "^7.4.0",
+				"istanbul-lib-coverage": "^2.0.5",
+				"semver": "^6.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+					"dev": true
+				}
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "2.0.8",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+			"integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
+			"dev": true,
+			"requires": {
+				"istanbul-lib-coverage": "^2.0.5",
+				"make-dir": "^2.1.0",
+				"supports-color": "^6.1.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "3.0.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+			"integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^2.0.5",
+				"make-dir": "^2.1.0",
+				"rimraf": "^2.6.3",
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+					"dev": true
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"dev": true
+				}
+			}
+		},
+		"istanbul-reports": {
+			"version": "2.2.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+			"integrity": "sha1-e08mYNgrKTA6j+YJH4ykvwWNoa8=",
+			"dev": true,
+			"requires": {
+				"handlebars": "^4.1.2"
+			}
+		},
+		"js-levenshtein": {
+			"version": "1.1.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+			"integrity": "sha1-xs7ljrNVA3LfjeuF+tXOZs4B1Z0=",
+			"dev": true
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.13.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+			"dev": true
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+			"dev": true
+		},
+		"json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
+		},
+		"json5": {
+			"version": "2.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/json5/-/json5-2.1.1.tgz",
+			"integrity": "sha1-gbbLBOm6SW8ccAXQe0NoomOPkLY=",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			}
+		},
+		"jsonschema": {
+			"version": "1.2.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/jsonschema/-/jsonschema-1.2.5.tgz",
+			"integrity": "sha1-uradl/oolGrsClapzCZtI/6ArmE="
+		},
+		"kind-of": {
+			"version": "6.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
+			"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+			"dev": true,
+			"optional": true
+		},
+		"latest-version": {
+			"version": "3.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/latest-version/-/latest-version-3.1.0.tgz",
+			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+			"dev": true,
+			"requires": {
+				"package-json": "^4.0.0"
+			}
+		},
+		"lcid": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/lcid/-/lcid-1.0.0.tgz",
+			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
+			"requires": {
+				"invert-kv": "^1.0.0"
+			}
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
+			}
+		},
+		"load-json-file": {
+			"version": "4.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
+			}
+		},
+		"load-yaml-file": {
+			"version": "0.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/load-yaml-file/-/load-yaml-file-0.1.1.tgz",
+			"integrity": "sha1-3JuOic7pZ1f28VpXB6xT92qlKek=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.5",
+				"js-yaml": "^3.13.0",
+				"pify": "^2.3.0",
+				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				}
+			}
+		},
+		"locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+			"requires": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.15",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
+			"dev": true
+		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+			"dev": true
+		},
+		"lodash.flattendeep": {
+			"version": "4.4.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+			"dev": true
+		},
+		"lodash.throttle": {
+			"version": "4.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
+			"dev": true
+		},
+		"lodash.toarray": {
+			"version": "4.4.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+			"integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+			"dev": true
+		},
+		"log-symbols": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/log-symbols/-/log-symbols-3.0.0.tgz",
+			"integrity": "sha1-86CFFqXeqJMzan3uFNGKHP2rd8Q=",
+			"requires": {
+				"chalk": "^2.4.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+			"dev": true,
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"loud-rejection": {
+			"version": "1.6.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
+			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"dev": true,
+			"requires": {
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
+			}
+		},
+		"lowercase-keys": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+			"dev": true
+		},
+		"lru-cache": {
+			"version": "4.1.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+			"dev": true,
+			"requires": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
+		},
+		"make-dir": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/make-dir/-/make-dir-2.1.0.tgz",
+			"integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+			"dev": true,
+			"requires": {
+				"pify": "^4.0.1",
+				"semver": "^5.6.0"
+			}
+		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true,
+			"optional": true
+		},
+		"map-obj": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/map-obj/-/map-obj-1.0.1.tgz",
+			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+			"dev": true
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"object-visit": "^1.0.0"
+			}
+		},
+		"mem": {
+			"version": "1.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^1.0.0"
+			},
+			"dependencies": {
+				"mimic-fn": {
+					"version": "1.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+					"integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+					"dev": true
+				}
+			}
+		},
+		"meow": {
+			"version": "3.7.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/meow/-/meow-3.7.0.tgz",
+			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+			"dev": true,
+			"requires": {
+				"camelcase-keys": "^2.0.0",
+				"decamelize": "^1.1.2",
+				"loud-rejection": "^1.0.0",
+				"map-obj": "^1.0.1",
+				"minimist": "^1.1.3",
+				"normalize-package-data": "^2.3.4",
+				"object-assign": "^4.0.1",
+				"read-pkg-up": "^1.0.1",
+				"redent": "^1.0.0",
+				"trim-newlines": "^1.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
+					"requires": {
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "^0.2.0"
+					}
+				}
+			}
+		},
+		"merge-source-map": {
+			"version": "1.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/merge-source-map/-/merge-source-map-1.1.0.tgz",
+			"integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
+			"dev": true,
+			"requires": {
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"dev": true
+				}
+			}
+		},
+		"micromatch": {
+			"version": "3.1.10",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
+			}
+		},
+		"mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
+		},
+		"mixin-deep": {
+			"version": "1.3.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
+			}
+		},
+		"mocha": {
+			"version": "6.2.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/mocha/-/mocha-6.2.2.tgz",
+			"integrity": "sha1-XYmH4olAyviVen12ZLkQ3Fsv6iA=",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "3.2.3",
+				"browser-stdout": "1.3.1",
+				"debug": "3.2.6",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"find-up": "3.0.0",
+				"glob": "7.1.3",
+				"growl": "1.10.5",
+				"he": "1.2.0",
+				"js-yaml": "3.13.1",
+				"log-symbols": "2.2.0",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"ms": "2.1.1",
+				"node-environment-flags": "1.0.5",
+				"object.assign": "4.1.0",
+				"strip-json-comments": "2.0.1",
+				"supports-color": "6.0.0",
+				"which": "1.3.1",
+				"wide-align": "1.1.3",
+				"yargs": "13.3.0",
+				"yargs-parser": "13.1.1",
+				"yargs-unparser": "1.6.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"log-symbols": {
+					"version": "2.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/log-symbols/-/log-symbols-2.2.0.tgz",
+					"integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
+					"dev": true
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-6.0.0.tgz",
+					"integrity": "sha1-ds/nQs8fQbubHCmtAwaMBbTA5Ao=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/which/-/which-1.3.1.tgz",
+					"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"yargs": {
+					"version": "13.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yargs/-/yargs-13.3.0.tgz",
+					"integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha1-0mBYUyqgbTZf4JH2ofwGsvfl7KA=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"mute-stream": {
+			"version": "0.0.8",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/mute-stream/-/mute-stream-0.0.8.tgz",
+			"integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0="
+		},
+		"nan": {
+			"version": "2.14.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw=",
+			"dev": true,
+			"optional": true
+		},
+		"nanomatch": {
+			"version": "1.2.13",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			}
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"neo-async": {
+			"version": "2.6.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/neo-async/-/neo-async-2.6.1.tgz",
+			"integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
+			"dev": true
+		},
+		"nested-error-stacks": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+			"integrity": "sha1-D73PPhP+SZR4EoBST4uWsM3/nGE=",
+			"dev": true
+		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+			"dev": true
+		},
+		"node-emoji": {
+			"version": "1.10.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/node-emoji/-/node-emoji-1.10.0.tgz",
+			"integrity": "sha1-iIar0l2ce7YYAqZYUj0fjSqJsto=",
+			"dev": true,
+			"requires": {
+				"lodash.toarray": "^4.4.0"
+			}
+		},
+		"node-environment-flags": {
+			"version": "1.0.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+			"integrity": "sha1-+pMCdfW/Xa4YjWGSsktMi7rD12o=",
+			"dev": true,
+			"requires": {
+				"object.getownpropertydescriptors": "^2.0.3",
+				"semver": "^5.7.0"
+			}
+		},
+		"node-modules-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+			"dev": true
+		},
+		"node-releases": {
+			"version": "1.1.45",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/node-releases/-/node-releases-1.1.45.tgz",
+			"integrity": "sha1-TPfpF11xsTF/Ff/WjOY7zh1T6fI=",
+			"dev": true,
+			"requires": {
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+					"dev": true
+				}
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+			"dev": true
+		},
+		"npm-check": {
+			"version": "5.9.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/npm-check/-/npm-check-5.9.0.tgz",
+			"integrity": "sha1-+WZq99PAJELhapxWoyq8YgI/oBk=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.6.1",
+				"callsite-record": "^3.0.0",
+				"chalk": "^1.1.3",
+				"co": "^4.6.0",
+				"depcheck": "^0.6.11",
+				"execa": "^0.2.2",
+				"giturl": "^1.0.0",
+				"global-modules": "^1.0.0",
+				"globby": "^4.0.0",
+				"inquirer": "^0.12.0",
+				"is-ci": "^1.0.8",
+				"lodash": "^4.7.0",
+				"meow": "^3.7.0",
+				"minimatch": "^3.0.2",
+				"node-emoji": "^1.0.3",
+				"ora": "^0.2.1",
+				"package-json": "^4.0.1",
+				"path-exists": "^2.1.0",
+				"pkg-dir": "^1.0.0",
+				"preferred-pm": "^1.0.1",
+				"semver": "^5.0.1",
+				"semver-diff": "^2.0.0",
+				"text-table": "^0.2.0",
+				"throat": "^2.0.2",
+				"update-notifier": "^2.1.0",
+				"xtend": "^4.0.1"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "1.4.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"cli-cursor": {
+					"version": "1.0.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cli-cursor/-/cli-cursor-1.0.2.tgz",
+					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+					"dev": true,
+					"requires": {
+						"restore-cursor": "^1.0.1"
+					}
+				},
+				"cli-spinners": {
+					"version": "0.1.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cli-spinners/-/cli-spinners-0.1.2.tgz",
+					"integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+					"dev": true
+				},
+				"figures": {
+					"version": "1.7.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/figures/-/figures-1.7.0.tgz",
+					"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "^1.0.5",
+						"object-assign": "^4.1.0"
+					}
+				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
+					"requires": {
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"inquirer": {
+					"version": "0.12.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/inquirer/-/inquirer-0.12.0.tgz",
+					"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "^1.1.0",
+						"ansi-regex": "^2.0.0",
+						"chalk": "^1.0.0",
+						"cli-cursor": "^1.0.1",
+						"cli-width": "^2.0.0",
+						"figures": "^1.3.5",
+						"lodash": "^4.3.0",
+						"readline2": "^1.0.1",
+						"run-async": "^0.1.0",
+						"rx-lite": "^3.1.2",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.0",
+						"through": "^2.3.6"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"onetime": {
+					"version": "1.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/onetime/-/onetime-1.1.0.tgz",
+					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+					"dev": true
+				},
+				"ora": {
+					"version": "0.2.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ora/-/ora-0.2.3.tgz",
+					"integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+					"dev": true,
+					"requires": {
+						"chalk": "^1.1.1",
+						"cli-cursor": "^1.0.2",
+						"cli-spinners": "^0.1.2",
+						"object-assign": "^4.0.1"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pkg-dir/-/pkg-dir-1.0.0.tgz",
+					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+					"dev": true,
+					"requires": {
+						"find-up": "^1.0.0"
+					}
+				},
+				"restore-cursor": {
+					"version": "1.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/restore-cursor/-/restore-cursor-1.0.1.tgz",
+					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+					"dev": true,
+					"requires": {
+						"exit-hook": "^1.0.0",
+						"onetime": "^1.0.0"
+					}
+				},
+				"run-async": {
+					"version": "0.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/run-async/-/run-async-0.1.0.tgz",
+					"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+					"dev": true,
+					"requires": {
+						"once": "^1.3.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
+			"requires": {
+				"path-key": "^2.0.0"
+			},
+			"dependencies": {
+				"path-key": {
+					"version": "2.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"dev": true
+				}
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
+		},
+		"nyc": {
+			"version": "14.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/nyc/-/nyc-14.1.1.tgz",
+			"integrity": "sha1-FR1kpqn59ZCKG3MjOTHkoKMHXus=",
+			"dev": true,
+			"requires": {
+				"archy": "^1.0.0",
+				"caching-transform": "^3.0.2",
+				"convert-source-map": "^1.6.0",
+				"cp-file": "^6.2.0",
+				"find-cache-dir": "^2.1.0",
+				"find-up": "^3.0.0",
+				"foreground-child": "^1.5.6",
+				"glob": "^7.1.3",
+				"istanbul-lib-coverage": "^2.0.5",
+				"istanbul-lib-hook": "^2.0.7",
+				"istanbul-lib-instrument": "^3.3.0",
+				"istanbul-lib-report": "^2.0.8",
+				"istanbul-lib-source-maps": "^3.0.6",
+				"istanbul-reports": "^2.2.4",
+				"js-yaml": "^3.13.1",
+				"make-dir": "^2.1.0",
+				"merge-source-map": "^1.1.0",
+				"resolve-from": "^4.0.0",
+				"rimraf": "^2.6.3",
+				"signal-exit": "^3.0.2",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^5.2.3",
+				"uuid": "^3.3.2",
+				"yargs": "^13.2.2",
+				"yargs-parser": "^13.0.0"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"yargs": {
+					"version": "13.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yargs/-/yargs-13.3.0.tgz",
+					"integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha1-0mBYUyqgbTZf4JH2ofwGsvfl7KA=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
+		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"object-inspect": {
+			"version": "1.7.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/object-inspect/-/object-inspect-1.7.0.tgz",
+			"integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=",
+			"dev": true
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+			"dev": true
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"isobject": "^3.0.0"
+			}
+		},
+		"object.assign": {
+			"version": "4.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/object.assign/-/object.assign-4.1.0.tgz",
+			"integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+			"integrity": "sha1-Npvx+VktiridcS3O1cuBx8U1Jkk=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"object.values": {
+			"version": "1.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/object.values/-/object.values-1.1.1.tgz",
+			"integrity": "sha1-aKmezeNWt+kpWjxeDOMdyMlT3l4=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"onetime": {
+			"version": "5.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/onetime/-/onetime-5.1.0.tgz",
+			"integrity": "sha1-//DzyRYX/mK7UBiWNumayKbfe+U=",
+			"requires": {
+				"mimic-fn": "^2.1.0"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
+			"requires": {
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
+				}
+			}
+		},
+		"optionator": {
+			"version": "0.8.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/optionator/-/optionator-0.8.3.tgz",
+			"integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
+			"dev": true,
+			"requires": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.6",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"word-wrap": "~1.2.3"
+			}
+		},
+		"ora": {
+			"version": "4.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ora/-/ora-4.0.3.tgz",
+			"integrity": "sha1-dSobe0vkglVGp6PVklb6UjtrbQU=",
+			"requires": {
+				"chalk": "^3.0.0",
+				"cli-cursor": "^3.1.0",
+				"cli-spinners": "^2.2.0",
+				"is-interactive": "^1.0.0",
+				"log-symbols": "^3.0.0",
+				"mute-stream": "0.0.8",
+				"strip-ansi": "^6.0.0",
+				"wcwidth": "^1.0.1"
+			}
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
+		},
+		"os-locale": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/os-locale/-/os-locale-2.1.0.tgz",
+			"integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+			"dev": true,
+			"requires": {
+				"execa": "^0.7.0",
+				"lcid": "^1.0.0",
+				"mem": "^1.1.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"execa": {
+					"version": "0.7.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/shebang-command/-/shebang-command-1.2.0.tgz",
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"dev": true
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/which/-/which-1.3.1.tgz",
+					"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
+		},
+		"p-limit": {
+			"version": "2.2.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/p-limit/-/p-limit-2.2.2.tgz",
+			"integrity": "sha1-YSebZ3IfUoeqHBOpp/u8SMkpGx4=",
+			"requires": {
+				"p-try": "^2.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+			"requires": {
+				"p-limit": "^2.0.0"
+			}
+		},
+		"p-try": {
+			"version": "2.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
+		},
+		"package-hash": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/package-hash/-/package-hash-3.0.0.tgz",
+			"integrity": "sha1-UBg/LTbJ4+Uo6gqGBd/1fOl2+I4=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.15",
+				"hasha": "^3.0.0",
+				"lodash.flattendeep": "^4.4.0",
+				"release-zalgo": "^1.0.0"
+			}
+		},
+		"package-json": {
+			"version": "4.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/package-json/-/package-json-4.0.1.tgz",
+			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+			"dev": true,
+			"requires": {
+				"got": "^6.7.1",
+				"registry-auth-token": "^3.0.1",
+				"registry-url": "^3.0.3",
+				"semver": "^5.1.0"
+			}
+		},
+		"parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0"
+			}
+		},
+		"parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"dev": true,
+			"requires": {
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
+			}
+		},
+		"parse-passwd": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+			"dev": true
+		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true,
+			"optional": true
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+			"dev": true,
+			"optional": true
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "3.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+			"dev": true
+		},
+		"path-type": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+			"dev": true,
+			"requires": {
+				"pify": "^3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
+			}
+		},
+		"pathval": {
+			"version": "1.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pathval/-/pathval-1.1.0.tgz",
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+			"dev": true
+		},
+		"picomatch": {
+			"version": "2.2.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/picomatch/-/picomatch-2.2.1.tgz",
+			"integrity": "sha1-IbrIiLbthgH4Mc54FuM1vHefCko=",
+			"dev": true
+		},
+		"pify": {
+			"version": "4.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+			"dev": true
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
+			"requires": {
+				"pinkie": "^2.0.0"
+			}
+		},
+		"pirates": {
+			"version": "4.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pirates/-/pirates-4.0.1.tgz",
+			"integrity": "sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=",
+			"dev": true,
+			"requires": {
+				"node-modules-regexp": "^1.0.0"
+			}
+		},
+		"pkg-dir": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0"
+			}
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true,
+			"optional": true
+		},
+		"preferred-pm": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/preferred-pm/-/preferred-pm-1.0.1.tgz",
+			"integrity": "sha1-U53zfOlEsbdlrpRKi6NKfmhpTo0=",
+			"dev": true,
+			"requires": {
+				"path-exists": "^3.0.0",
+				"which-pm": "^1.0.1"
+			}
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+			"dev": true
+		},
+		"private": {
+			"version": "0.1.8",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/private/-/private-0.1.8.tgz",
+			"integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
+			"dev": true
+		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+			"dev": true,
+			"optional": true
+		},
+		"progress": {
+			"version": "2.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
+			"dev": true
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+			"dev": true
+		},
+		"ramda": {
+			"version": "0.26.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ramda/-/ramda-0.26.1.tgz",
+			"integrity": "sha1-jUE1HrgRHFU1Nhf8O7/62OTTXQY=",
+			"dev": true
+		},
+		"rc": {
+			"version": "1.2.8",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
+			"dev": true,
+			"requires": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"dependencies": {
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"dev": true
+				}
+			}
+		},
+		"read-pkg": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"dev": true,
+			"requires": {
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "4.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+			"integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0",
+				"read-pkg": "^3.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"readdirp": {
+			"version": "2.2.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/readdirp/-/readdirp-2.2.1.tgz",
+			"integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"micromatch": "^3.1.10",
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"readline2": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/readline2/-/readline2-1.0.1.tgz",
+			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+			"dev": true,
+			"requires": {
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"mute-stream": "0.0.5"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"mute-stream": {
+					"version": "0.0.5",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/mute-stream/-/mute-stream-0.0.5.tgz",
+					"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+					"dev": true
+				}
+			}
+		},
+		"redent": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/redent/-/redent-1.0.0.tgz",
+			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+			"dev": true,
+			"requires": {
+				"indent-string": "^2.1.0",
+				"strip-indent": "^1.0.1"
+			}
+		},
+		"regenerate": {
+			"version": "1.4.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/regenerate/-/regenerate-1.4.0.tgz",
+			"integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE=",
+			"dev": true
+		},
+		"regenerate-unicode-properties": {
+			"version": "8.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+			"integrity": "sha1-71Hg8OpK1CS3e/fLQfPgFccKPw4=",
+			"dev": true,
+			"requires": {
+				"regenerate": "^1.4.0"
+			}
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
+			"dev": true
+		},
+		"regenerator-transform": {
+			"version": "0.14.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+			"integrity": "sha1-Oy/OThq3cywI9mXf2zFHScfd0vs=",
+			"dev": true,
+			"requires": {
+				"private": "^0.1.6"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"regexpp": {
+			"version": "2.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/regexpp/-/regexpp-2.0.1.tgz",
+			"integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
+			"dev": true
+		},
+		"regexpu-core": {
+			"version": "4.6.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/regexpu-core/-/regexpu-core-4.6.0.tgz",
+			"integrity": "sha1-IDfBizJ8/Oim/qKk7EQfJDKvuLY=",
+			"dev": true,
+			"requires": {
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^8.1.0",
+				"regjsgen": "^0.5.0",
+				"regjsparser": "^0.6.0",
+				"unicode-match-property-ecmascript": "^1.0.4",
+				"unicode-match-property-value-ecmascript": "^1.1.0"
+			}
+		},
+		"registry-auth-token": {
+			"version": "3.4.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+			"integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
+			"dev": true,
+			"requires": {
+				"rc": "^1.1.6",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"registry-url": {
+			"version": "3.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/registry-url/-/registry-url-3.1.0.tgz",
+			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+			"dev": true,
+			"requires": {
+				"rc": "^1.0.1"
+			}
+		},
+		"regjsgen": {
+			"version": "0.5.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/regjsgen/-/regjsgen-0.5.1.tgz",
+			"integrity": "sha1-SPC/Gl6iBRlpKcDZeYtC0e2YRDw=",
+			"dev": true
+		},
+		"regjsparser": {
+			"version": "0.6.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/regjsparser/-/regjsparser-0.6.2.tgz",
+			"integrity": "sha1-/WLHU5kUZ9nR/+Cp9n8npSkCS5Y=",
+			"dev": true,
+			"requires": {
+				"jsesc": "~0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				}
+			}
+		},
+		"release-zalgo": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/release-zalgo/-/release-zalgo-1.0.0.tgz",
+			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+			"dev": true,
+			"requires": {
+				"es6-error": "^4.0.1"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true,
+			"optional": true
+		},
+		"repeat-element": {
+			"version": "1.1.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
+			"dev": true,
+			"optional": true
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true,
+			"optional": true
+		},
+		"repeating": {
+			"version": "2.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
+			"requires": {
+				"is-finite": "^1.0.0"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs="
+		},
+		"require-package-name": {
+			"version": "2.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/require-package-name/-/require-package-name-2.0.1.tgz",
+			"integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=",
+			"dev": true
+		},
+		"resolve": {
+			"version": "1.14.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/resolve/-/resolve-1.14.2.tgz",
+			"integrity": "sha1-2/MdD6mLHymqUWl4O5wpDLhl/qI=",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-dir": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/resolve-dir/-/resolve-dir-1.0.1.tgz",
+			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+			"dev": true,
+			"requires": {
+				"expand-tilde": "^2.0.0",
+				"global-modules": "^1.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+			"dev": true
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true,
+			"optional": true
+		},
+		"restore-cursor": {
+			"version": "3.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
+			"requires": {
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
+			"dev": true,
+			"optional": true
+		},
+		"rimraf": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/rimraf/-/rimraf-3.0.0.tgz",
+			"integrity": "sha1-YUF21LMBC3Xlw5DrDulvbcDOu5s=",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
+			"requires": {
+				"is-promise": "^2.1.0"
+			}
+		},
+		"rx-lite": {
+			"version": "3.1.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/rx-lite/-/rx-lite-3.1.2.tgz",
+			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+			"dev": true
+		},
+		"rxjs": {
+			"version": "6.5.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/rxjs/-/rxjs-6.5.4.tgz",
+			"integrity": "sha1-4Hd/4NGEzseHLfFH8wNXLUFOIRw=",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.9.0"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+			"dev": true
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"ret": "~0.1.10"
+			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+			"dev": true
+		},
+		"semver": {
+			"version": "5.7.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+			"dev": true
+		},
+		"semver-diff": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/semver-diff/-/semver-diff-2.1.0.tgz",
+			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+			"dev": true,
+			"requires": {
+				"semver": "^5.0.3"
+			}
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"set-value": {
+			"version": "2.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^3.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"slash": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
+			"dev": true
+		},
+		"slice-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/slice-ansi/-/slice-ansi-2.1.0.tgz",
+			"integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"astral-regex": "^1.0.0",
+				"is-fullwidth-code-point": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				}
+			}
+		},
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
+		},
+		"source-map-resolve": {
+			"version": "0.5.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+			"integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"atob": "^2.1.2",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
+		"source-map-support": {
+			"version": "0.5.16",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/source-map-support/-/source-map-support-0.5.16.tgz",
+			"integrity": "sha1-CuBp5/47p1OMZMmFFeNTOerFoEI=",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"dev": true
+				}
+			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true,
+			"optional": true
+		},
+		"spawn-wrap": {
+			"version": "1.4.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/spawn-wrap/-/spawn-wrap-1.4.3.tgz",
+			"integrity": "sha1-gbdnDhcMyiR9gL9frwz7cTvc+Eg=",
+			"dev": true,
+			"requires": {
+				"foreground-child": "^1.5.6",
+				"mkdirp": "^0.5.0",
+				"os-homedir": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.2",
+				"which": "^1.3.0"
+			},
+			"dependencies": {
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/which/-/which-1.3.1.tgz",
+					"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
+		"spdx-correct": {
+			"version": "3.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
+			"dev": true,
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
+			"dev": true
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+			"dev": true,
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+			"integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
+			"dev": true
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"stackframe": {
+			"version": "0.3.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/stackframe/-/stackframe-0.3.1.tgz",
+			"integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=",
+			"dev": true
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"stream-chain": {
+			"version": "2.2.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/stream-chain/-/stream-chain-2.2.1.tgz",
+			"integrity": "sha1-5u/e6J7vgUgdiIGByhdfOr4D85Y="
+		},
+		"stream-json": {
+			"version": "1.3.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/stream-json/-/stream-json-1.3.2.tgz",
+			"integrity": "sha1-yQqSDA+pva74IAKvM4P1RtQvKbM=",
+			"requires": {
+				"stream-chain": "^2.2.1"
+			}
+		},
+		"string-width": {
+			"version": "3.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
+			"integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+			"requires": {
+				"emoji-regex": "^7.0.1",
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^5.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
+			}
+		},
+		"string.prototype.trimleft": {
+			"version": "2.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+			"integrity": "sha1-m9uKxqvW1gKxek7TIYcNL43O/HQ=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
+		"string.prototype.trimright": {
+			"version": "2.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+			"integrity": "sha1-RAMUsVmWyGbOigNBiU1FGGIAxdk=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"strip-ansi": {
+			"version": "6.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+			"integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+			"requires": {
+				"ansi-regex": "^5.0.0"
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
+		},
+		"strip-indent": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-indent/-/strip-indent-1.0.1.tgz",
+			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+			"dev": true,
+			"requires": {
+				"get-stdin": "^4.0.1"
+			}
+		},
+		"strip-json-comments": {
+			"version": "3.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+			"integrity": "sha1-hXE5dakfuHvxswXMp3OV5A0qZKc=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "7.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-7.1.0.tgz",
+			"integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+			"requires": {
+				"has-flag": "^4.0.0"
+			}
+		},
+		"table": {
+			"version": "5.4.6",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/table/-/table-5.4.6.tgz",
+			"integrity": "sha1-EpLRlQDOP4YFOwXw6Ofko7shB54=",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.10.2",
+				"lodash": "^4.17.14",
+				"slice-ansi": "^2.1.0",
+				"string-width": "^3.0.0"
+			}
+		},
+		"term-size": {
+			"version": "1.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/term-size/-/term-size-1.2.0.tgz",
+			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+			"dev": true,
+			"requires": {
+				"execa": "^0.7.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"execa": {
+					"version": "0.7.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/shebang-command/-/shebang-command-1.2.0.tgz",
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"dev": true
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/which/-/which-1.3.1.tgz",
+					"integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
+		"test-exclude": {
+			"version": "5.2.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/test-exclude/-/test-exclude-5.2.3.tgz",
+			"integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3",
+				"minimatch": "^3.0.4",
+				"read-pkg-up": "^4.0.0",
+				"require-main-filename": "^2.0.0"
+			}
+		},
+		"text-encoding": {
+			"version": "0.7.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/text-encoding/-/text-encoding-0.7.0.tgz",
+			"integrity": "sha1-+JXoNuRZkGJAhmAXmOqY6PNu5kM="
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
+		},
+		"throat": {
+			"version": "2.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/throat/-/throat-2.0.2.tgz",
+			"integrity": "sha1-qfzoCLaeEzpjJZB4DzQsMKYkmwI=",
+			"dev": true
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
+		},
+		"timed-out": {
+			"version": "4.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/timed-out/-/timed-out-4.0.1.tgz",
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+			"dev": true
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "~1.0.2"
+			}
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
+			}
+		},
+		"trim-newlines": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/trim-newlines/-/trim-newlines-1.0.0.tgz",
+			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+			"dev": true
+		},
+		"tslib": {
+			"version": "1.10.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/tslib/-/tslib-1.10.0.tgz",
+			"integrity": "sha1-w8GflZc/sKYpc/sJ2Q2WHuQ+XIo=",
+			"dev": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2"
+			}
+		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+			"dev": true
+		},
+		"type-fest": {
+			"version": "0.8.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
+			"dev": true
+		},
+		"uglify-js": {
+			"version": "3.7.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/uglify-js/-/uglify-js-3.7.4.tgz",
+			"integrity": "sha1-5tg6GqMv9Ei9Fnk1mrE9jbD+B0M=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"commander": "~2.20.3",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+					"dev": true,
+					"optional": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+			"integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg=",
+			"dev": true
+		},
+		"unicode-match-property-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+			"integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
+			"dev": true,
+			"requires": {
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
+			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+			"integrity": "sha1-W0tCbgjROoA2Xg1lesemwexGonc=",
+			"dev": true
+		},
+		"unicode-property-aliases-ecmascript": {
+			"version": "1.0.5",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+			"integrity": "sha1-qcxsx85joKMCP8meNBuUQx1AWlc=",
+			"dev": true
+		},
+		"union-value": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^2.0.1"
+			}
+		},
+		"unique-string": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/unique-string/-/unique-string-1.0.0.tgz",
+			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"dev": true,
+			"requires": {
+				"crypto-random-string": "^1.0.0"
+			}
+		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://eis.jfrog.io/eis/api/npm/npm/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"unzip-response": {
+			"version": "2.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/unzip-response/-/unzip-response-2.0.1.tgz",
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+			"dev": true
+		},
+		"upath": {
+			"version": "1.2.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/upath/-/upath-1.2.0.tgz",
+			"integrity": "sha1-j2bbzVWog6za5ECK+LA1pQRMGJQ=",
+			"dev": true,
+			"optional": true
+		},
+		"update-notifier": {
+			"version": "2.5.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/update-notifier/-/update-notifier-2.5.0.tgz",
+			"integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
+			"dev": true,
+			"requires": {
+				"boxen": "^1.2.1",
+				"chalk": "^2.0.1",
+				"configstore": "^3.0.0",
+				"import-lazy": "^2.1.0",
+				"is-ci": "^1.0.10",
+				"is-installed-globally": "^0.1.0",
+				"is-npm": "^1.0.0",
+				"latest-version": "^3.0.0",
+				"semver-diff": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true,
+			"optional": true
+		},
+		"url-parse-lax": {
+			"version": "1.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+			"dev": true,
+			"requires": {
+				"prepend-http": "^1.0.1"
+			}
+		},
+		"use": {
+			"version": "3.1.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/use/-/use-3.1.1.tgz",
+			"integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
+			"dev": true,
+			"optional": true
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true,
+			"optional": true
+		},
+		"uuid": {
+			"version": "3.3.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/uuid/-/uuid-3.3.3.tgz",
+			"integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+			"dev": true
+		},
+		"v8-compile-cache": {
+			"version": "2.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+			"integrity": "sha1-4U3jezGm0ZT1aQ1n78Tn9vxqsw4=",
+			"dev": true
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+			"dev": true,
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"walkdir": {
+			"version": "0.0.11",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/walkdir/-/walkdir-0.0.11.tgz",
+			"integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
+			"dev": true
+		},
+		"wcwidth": {
+			"version": "1.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/wcwidth/-/wcwidth-1.0.1.tgz",
+			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+			"requires": {
+				"defaults": "^1.0.3"
+			}
+		},
+		"which": {
+			"version": "2.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/which/-/which-2.0.2.tgz",
+			"integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
+		"which-pm": {
+			"version": "1.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/which-pm/-/which-pm-1.1.0.tgz",
+			"integrity": "sha1-XA/D9yLwA3B96nsgzRfv/TrS/DM=",
+			"dev": true,
+			"requires": {
+				"load-yaml-file": "^0.1.0",
+				"path-exists": "^3.0.0"
+			}
+		},
+		"wide-align": {
+			"version": "1.1.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/wide-align/-/wide-align-1.1.3.tgz",
+			"integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.2 || 2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"widest-line": {
+			"version": "2.0.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/widest-line/-/widest-line-2.0.1.tgz",
+			"integrity": "sha1-dDh2RzDsfvQ4HOTfgvuYpTFCo/w=",
+			"dev": true,
+			"requires": {
+				"string-width": "^2.1.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
+			"dev": true
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "5.1.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+			"integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"string-width": "^3.0.0",
+				"strip-ansi": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"write": {
+			"version": "1.0.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/write/-/write-1.0.3.tgz",
+			"integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
+			"dev": true,
+			"requires": {
+				"mkdirp": "^0.5.1"
+			}
+		},
+		"write-file-atomic": {
+			"version": "2.4.3",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+			"integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"xdg-basedir": {
+			"version": "3.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+			"dev": true
+		},
+		"xmldom": {
+			"version": "0.2.1",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/xmldom/-/xmldom-0.2.1.tgz",
+			"integrity": "sha1-yslGUGbxYeHDMCeT6k2+WcUYJ08="
+		},
+		"xtend": {
+			"version": "4.0.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
+			"dev": true
+		},
+		"y18n": {
+			"version": "4.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
+		},
+		"yargs": {
+			"version": "14.2.2",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yargs/-/yargs-14.2.2.tgz",
+			"integrity": "sha1-J2lWQ3kAn/hZfN04+6CdqbSTxLU=",
+			"requires": {
+				"cliui": "^5.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^3.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^15.0.0"
+			}
+		},
+		"yargs-parser": {
+			"version": "15.0.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yargs-parser/-/yargs-parser-15.0.0.tgz",
+			"integrity": "sha1-zdepdJDsg2GV9Z8/Tb5eqej3Xwg=",
+			"requires": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			}
+		},
+		"yargs-unparser": {
+			"version": "1.6.0",
+			"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+			"integrity": "sha1-7yXCx2n/a9CeSw+dfGBfsnhG6p8=",
+			"dev": true,
+			"requires": {
+				"flat": "^4.1.0",
+				"lodash": "^4.17.15",
+				"yargs": "^13.3.0"
+			},
+			"dependencies": {
+				"yargs": {
+					"version": "13.3.0",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yargs/-/yargs-13.3.0.tgz",
+					"integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.1",
+					"resolved": "https://eis.jfrog.io/eis/api/npm/npm/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha1-0mBYUyqgbTZf4JH2ofwGsvfl7KA=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@natlibfi/marc-record-serializers",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"url": "git@github.com:natlibfi/marc-record-serializers.git"
 	},
 	"license": "MIT",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"main": "./dist/index.js",
 	"bin": "./dist/cli.js",
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,6 @@
 		"watch:serializer": "cross-env DEBUG=1 NODE_ENV=test chokidar src/$SERIALIZER.js src/$SERIALIZER.spec.js -c 'npm run lint:base -- src/$SERIALIZER.js src/$SERIALIZER.spec.js && npm run test:unit:base -- src/$SERIALIZER.spec.js'"
 	},
 	"dependencies": {
-		"@babel/core": "^7.6.4",
-		"@babel/register": "^7.6.2",
 		"@natlibfi/marc-record": "^4.0.4",
 		"ora": "^4.0.2",
 		"stream-json": "^1.1.4",
@@ -53,6 +51,8 @@
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.6.4",
+		"@babel/core": "^7.6.4",
+		"@babel/register": "^7.6.2",
 		"@babel/preset-env": "^7.6.3",
 		"babel-eslint": "^10.0.1",
 		"babel-plugin-istanbul": "^5.1.1",


### PR DESCRIPTION
Since `@babel/register` isn't being called anywhere in code (just used when running mocha/nyc), seems like it makes sense to move it to devDependencies to make a leaner package and reduce potential npm audit issues for consumers.

Also checked in the package-lock as that's standard practice in my view. If you want me to back that out, though, I'll be happy to do so. Thanks!