### PR TITLE
Read marcxml with namespace prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ reader.on('data', record => console.log(record));
 ```
 ### Serializers
 #### MARCXML
-- **from**: The seconds argument is a validation options object (See [@natlibfi/marc-record](https://www.npmjs.com/package/@natlibfi/marc-record))
+- **reader**: The third argument is a XML namespace prefix string (colon included) used in marcxml (fe. 'marc:'). Defaults to no prefix.
+- **from**: The second argument is a validation options object (See [@natlibfi/marc-record](https://www.npmjs.com/package/@natlibfi/marc-record))
 - **to**: An object can be passed in as the second argument. It supports the following properties:
   - **omitDeclaration**: Whether to omit XML declaration. Defaults to *false*.
   - **indent**: Whether to indent te XML. Defaults to *false*.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ reader.on('data', record => console.log(record));
 ```
 ### Serializers
 #### MARCXML
-- **reader**: The third argument is a XML namespace prefix string (colon included) used in marcxml (fe. 'marc:'). Defaults to no prefix.
+- **reader**: The third argument is a XML namespace prefix used in marcxml (fe. 'marc'). Defaults to no prefix.
 - **from**: The second argument is a validation options object (See [@natlibfi/marc-record](https://www.npmjs.com/package/@natlibfi/marc-record))
 - **to**: An object can be passed in as the second argument. It supports the following properties:
   - **omitDeclaration**: Whether to omit XML declaration. Defaults to *false*.

--- a/src/cli.js
+++ b/src/cli.js
@@ -53,6 +53,7 @@ async function run() {
       .option('v', {alias: 'validate', default: true, type: 'boolean', describe: 'Validate MARC record structure'})
       .option('o', {alias: 'validationOptions', default: '111', type: 'string', describe: 'Boolean numbers declaring validation options'})
       .option('d', {alias: 'outputDirectory', type: 'string', describe: 'Write records to individual files in DIRECTORY'})
+      .option('n', {alias: 'marcXmlNameSpace', type: 'string', describe: 'Namespace prefix used for marcxml reader'})
       .epilogue(VALIDATION_OPTIONS_USAGE)
       .epilogue(FORMAT_USAGE)
       .parse();
@@ -60,7 +61,8 @@ async function run() {
     const {serialize, outputPrefix, outputSuffix, outputSeparator, fileSuffix, recordCallback} = getService(args.outputFormat);
     const {reader} = getService(args.inputFormat);
     const validationOptions = args.validate ? handleValidationOptions(args.validationOptions) : {fields: false, subfields: false, subfieldValues: false};
-    const readerFromFile = reader(fs.createReadStream(args.file), validationOptions);
+    const marcXmlNameSpace = args.marcXmlNameSpace || '';
+    const readerFromFile = reader(fs.createReadStream(args.file), validationOptions, marcXmlNameSpace);
 
     //console.log('Converting records.');
     //console.log(validationOptions);

--- a/src/marcxml.js
+++ b/src/marcxml.js
@@ -26,6 +26,8 @@ const debugData = debug.extend('data');
 
 export function reader (stream, validationOptions = {}, nameSpace = '') {
   const emitter = new class extends EventEmitter { }();
+  const nameSpacePrefix = nameSpace === '' ? nameSpace : `${nameSpace}:`;
+
   MarcRecord.setValidationOptions(validationOptions);
 
   start();
@@ -49,24 +51,24 @@ export function reader (stream, validationOptions = {}, nameSpace = '') {
       // eslint-disable-next-line functional/no-loop-statement
       while (1) { // eslint-disable-line no-constant-condition
         // eslint-disable-next-line functional/no-let
-        let pos = charbuffer.indexOf(`<${nameSpace}record`);
+        let pos = charbuffer.indexOf(`<${nameSpacePrefix}record`);
 
         if (pos === -1) {
           return;
         }
 
-        debug(`Found record start "<${nameSpace}record" in pos ${pos}`);
+        debug(`Found record start "<${nameSpacePrefix}record" in pos ${pos}`);
 
         charbuffer = charbuffer.substr(pos);
-        pos = charbuffer.indexOf(`</${nameSpace}record>`);
+        pos = charbuffer.indexOf(`</${nameSpacePrefix}record>`);
         /* istanbul ignore if */
         if (pos === -1) {
           return;
         }
 
-        debug(`Found record end "</${nameSpace}record>" in pos ${pos}`);
+        debug(`Found record end "</${nameSpacePrefix}record>" in pos ${pos}`);
 
-        const endTagLength = nameSpace.length + 9;
+        const endTagLength = nameSpacePrefix.length + 9;
         const raw = charbuffer.substr(0, pos + endTagLength);
         charbuffer = charbuffer.substr(pos + endTagLength);
 

--- a/src/marcxml.spec.js
+++ b/src/marcxml.spec.js
@@ -133,9 +133,7 @@ describe('marcxml', () => {
         const records = [];
         const fromPath = path.resolve(fixturesPath, `from-namespace-xml${index}`);
         const expectedRecord = fs.readFileSync(path.resolve(fixturesPath, `to-namespace-xml${index}`), 'utf8');
-        // eslint-disable-next-line no-console
-        console.log(expectedRecord);
-        const reader = Converter.reader(fs.createReadStream(fromPath), {subfieldValues: false}, 'marc:');
+        const reader = Converter.reader(fs.createReadStream(fromPath), {subfieldValues: false}, 'marc');
 
         reader.on('error', reject);
         // eslint-disable-next-line functional/immutable-data
@@ -144,8 +142,6 @@ describe('marcxml', () => {
           try {
             expect(records).to.have.length(1);
             const [firstRecord] = records;
-            // eslint-disable-next-line no-console
-            console.log(firstRecord.toString());
             expect(firstRecord.toString()).to.equal(expectedRecord);
             resolve();
           } catch (err) {

--- a/src/marcxml.spec.js
+++ b/src/marcxml.spec.js
@@ -125,6 +125,37 @@ describe('marcxml', () => {
     });
   });
 
+  const fixtureCountNamespace = fs.readdirSync(fixturesPath).filter(f => (/^from-namespace-xml[0-9]+/u).test(f)).length;
+  describe('#namespace-xml', () => {
+    Array.from(Array(fixtureCountNamespace)).forEach((e, i) => {
+      const index = i + 1;
+      it(`Should convert file from-namepace-xml${index} to file to-namespace-xml${index}`, () => new Promise((resolve, reject) => {
+        const records = [];
+        const fromPath = path.resolve(fixturesPath, `from-namespace-xml${index}`);
+        const expectedRecord = fs.readFileSync(path.resolve(fixturesPath, `to-namespace-xml${index}`), 'utf8');
+        // eslint-disable-next-line no-console
+        console.log(expectedRecord);
+        const reader = Converter.reader(fs.createReadStream(fromPath), {subfieldValues: false}, 'marc:');
+
+        reader.on('error', reject);
+        // eslint-disable-next-line functional/immutable-data
+        reader.on('data', record => records.push(record));
+        reader.on('end', () => {
+          try {
+            expect(records).to.have.length(1);
+            const [firstRecord] = records;
+            // eslint-disable-next-line no-console
+            console.log(firstRecord.toString());
+            expect(firstRecord.toString()).to.equal(expectedRecord);
+            resolve();
+          } catch (err) {
+            reject(err);
+          }
+        });
+      }));
+    });
+  });
+
   describe('#to', () => {
     it('Should serialize the record without XML declaration', () => {
       const expectedRecord = fs.readFileSync(path.resolve(fixturesPath, 'to-no-xml-decl'), 'utf8');

--- a/test-fixtures/marcxml/from-namespace-xml1
+++ b/test-fixtures/marcxml/from-namespace-xml1
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<marc:record xmlns:marc="http://www.loc.gov/MARC21/slim">
+  <marc:leader>     nam a22     4i 4500</marc:leader>
+  <marc:controlfield tag="001">017379727</marc:controlfield>
+  <marc:controlfield tag="003">DLC</marc:controlfield>
+  <marc:controlfield tag="005">20201115152306.0</marc:controlfield>
+  <marc:controlfield tag="008">200807s2020    xxk           00| f eng |</marc:controlfield>
+  <marc:datafield tag="020" ind1=" " ind2=" ">
+    <marc:subfield code="a">978-0-00-837611-6</marc:subfield>
+    <marc:subfield code="q">sidottu</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="035" ind1=" " ind2=" ">
+    <marc:subfield code="a">017379727</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="041" ind1=" " ind2=" ">
+    <marc:subfield code="a">eng</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="084" ind1=" " ind2=" ">
+    <marc:subfield code="a">84.5</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="084" ind1=" " ind2=" ">
+    <marc:subfield code="a">Fantasia</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="100" ind1="1" ind2=" ">
+    <marc:subfield code="a">Tolkien, J. R. R., 1892-1973</marc:subfield>
+    <marc:subfield code="e">kirjoittaja</marc:subfield>
+    <marc:subfield code="0">000147928</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="245" ind1="1" ind2="0">
+    <marc:subfield code="a">The hobbit or There and back again</marc:subfield>
+    <marc:subfield code="c">by J.R.R. Tolkien ; illustrated by Alan Lee</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="250" ind1=" " ind2=" ">
+    <marc:subfield code="a">Illustrated hardback edition</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="264" ind1=" " ind2="1">
+    <marc:subfield code="a">http://id.loc.gov/vocabulary/countries/xxk</marc:subfield>
+    <marc:subfield code="c">2020</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="264" ind1=" " ind2="1">
+    <marc:subfield code="a">London</marc:subfield>
+    <marc:subfield code="b">HarperCollinsPublishers</marc:subfield>
+    <marc:subfield code="c">2020</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="300" ind1=" " ind2=" ">
+    <marc:subfield code="a">viii, 307 sivua</marc:subfield>
+    <marc:subfield code="c">23 cm</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="336" ind1=" " ind2=" ">
+    <marc:subfield code="a">text</marc:subfield>
+    <marc:subfield code="0">http://id.loc.gov/vocabulary/contentTypes/txt</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="336" ind1=" " ind2=" ">
+    <marc:subfield code="a">teksti</marc:subfield>
+    <marc:subfield code="0">http://id.loc.gov/vocabulary/contentTypes/txt</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="337" ind1=" " ind2=" ">
+    <marc:subfield code="a">käytettävissä ilman laitetta</marc:subfield>
+    <marc:subfield code="0">http://id.loc.gov/vocabulary/mediaTypes/n</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="338" ind1=" " ind2=" ">
+    <marc:subfield code="a">nide</marc:subfield>
+    <marc:subfield code="0">http://id.loc.gov/vocabulary/carriers/nc</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="500" ind1=" " ind2=" ">
+    <marc:subfield code="a">kuvitettu, karttoja</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="520" ind1=" " ind2=" ">
+    <marc:subfield code="a">Whisked away from his comfortable, unambitious life in his hobbit-hole in Bag End by Gandalf the wizard and a band of dwarves, Bilbo Baggins finds himself caught up in a plot to raid the treasure hoard of Smaug the Magnificent, a large and very dangerous dragon. Although quite reluctant to take part in this quest, Bilbo surprises even himself by his resourcefulness and his skill as a burglar. The text of this edition has been fully corrected and revised in collaboration with Christopher Tolkien and is accompanied by a wealth of beautiful watercolour paintings and delicate pencil drawings from Alan Lee.</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="546" ind1=" " ind2=" ">
+    <marc:subfield code="a">englanti.</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="600" ind1="1" ind2="4">
+    <marc:subfield code="a">Gandalf (fiktiivinen hahmo)</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="600" ind1="1" ind2="4">
+    <marc:subfield code="a">Baggins, Bilbo (fiktiivinen hahmo)</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="650" ind1=" " ind2="7">
+    <marc:subfield code="a">seikkailu</marc:subfield>
+    <marc:subfield code="0">http://www.yso.fi/onto/kauno/p2904</marc:subfield>
+    <marc:subfield code="2">kauno/fin</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="650" ind1=" " ind2="7">
+    <marc:subfield code="a">matkat</marc:subfield>
+    <marc:subfield code="0">http://www.yso.fi/onto/kauno/p3013</marc:subfield>
+    <marc:subfield code="2">kauno/fin</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="650" ind1=" " ind2="7">
+    <marc:subfield code="a">aarteenetsintä</marc:subfield>
+    <marc:subfield code="0">http://www.yso.fi/onto/kauno/p4310</marc:subfield>
+    <marc:subfield code="2">kauno/fin</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="650" ind1=" " ind2="7">
+    <marc:subfield code="a">sormukset</marc:subfield>
+    <marc:subfield code="0">http://www.yso.fi/onto/kauno/p3678</marc:subfield>
+    <marc:subfield code="2">kauno/fin</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="650" ind1=" " ind2="7">
+    <marc:subfield code="a">velhot</marc:subfield>
+    <marc:subfield code="0">http://www.yso.fi/onto/kauno/p4407</marc:subfield>
+    <marc:subfield code="2">kauno/fin</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="650" ind1=" " ind2="7">
+    <marc:subfield code="a">kääpiöt</marc:subfield>
+    <marc:subfield code="0">http://www.yso.fi/onto/kauno/p738</marc:subfield>
+    <marc:subfield code="2">kauno/fin</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="651" ind1=" " ind2="4">
+    <marc:subfield code="a">Middle-earth (fiktiivinen paikka)</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="655" ind1=" " ind2="7">
+    <marc:subfield code="a">novels</marc:subfield>
+    <marc:subfield code="0">http://id.loc.gov/authorities/genreForms/gf2015026020</marc:subfield>
+    <marc:subfield code="2">lcgft</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="655" ind1=" " ind2="7">
+    <marc:subfield code="a">fantasiakirjallisuus</marc:subfield>
+    <marc:subfield code="0">http://urn.fi/URN:NBN:fi:au:slm:s1140</marc:subfield>
+    <marc:subfield code="2">slm/fin</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="655" ind1=" " ind2="7">
+    <marc:subfield code="a">romaanit</marc:subfield>
+    <marc:subfield code="0">http://urn.fi/URN:NBN:fi:au:slm:s518</marc:subfield>
+    <marc:subfield code="2">slm/fin</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="655" ind1=" " ind2="7">
+    <marc:subfield code="a">kaunokirjallisuus</marc:subfield>
+    <marc:subfield code="0">http://urn.fi/URN:NBN:fi:au:slm:s975</marc:subfield>
+    <marc:subfield code="2">slm/fin</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="655" ind1=" " ind2="7">
+    <marc:subfield code="a">fantasylitteratur</marc:subfield>
+    <marc:subfield code="0">http://urn.fi/URN:NBN:fi:au:slm:s1140</marc:subfield>
+    <marc:subfield code="2">slm/swe</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="655" ind1=" " ind2="7">
+    <marc:subfield code="a">romaner</marc:subfield>
+    <marc:subfield code="0">http://urn.fi/URN:NBN:fi:au:slm:s518</marc:subfield>
+    <marc:subfield code="2">slm/swe</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="655" ind1=" " ind2="7">
+    <marc:subfield code="a">skönlitteratur</marc:subfield>
+    <marc:subfield code="0">http://urn.fi/URN:NBN:fi:au:slm:s975</marc:subfield>
+    <marc:subfield code="2">slm/swe</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="700" ind1="1" ind2=" ">
+    <marc:subfield code="a">Lee, Alan</marc:subfield>
+    <marc:subfield code="e">kuvittaja</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="884" ind1=" " ind2=" ">
+    <marc:subfield code="a">DLC bibframe2marc v1.1.0-SNAPSHOT</marc:subfield>
+    <marc:subfield code="g">20211123170406.0</marc:subfield>
+    <marc:subfield code="q">DLC</marc:subfield>
+    <marc:subfield code="u">https://github.com/lcnetdev/bibframe2marc</marc:subfield>
+  </marc:datafield>
+</marc:record>

--- a/test-fixtures/marcxml/to-namespace-xml1
+++ b/test-fixtures/marcxml/to-namespace-xml1
@@ -1,0 +1,41 @@
+LDR         nam a22     4i 4500
+001    017379727
+003    DLC
+005    20201115152306.0
+008    200807s2020    xxk           00| f eng |
+020    ‡a978-0-00-837611-6‡qsidottu
+035    ‡a017379727
+041    ‡aeng
+084    ‡a84.5
+084    ‡aFantasia
+100 1  ‡aTolkien, J. R. R., 1892-1973‡ekirjoittaja‡0000147928
+245 10 ‡aThe hobbit or There and back again‡cby J.R.R. Tolkien ; illustrated by Alan Lee
+250    ‡aIllustrated hardback edition
+264  1 ‡ahttp://id.loc.gov/vocabulary/countries/xxk‡c2020
+264  1 ‡aLondon‡bHarperCollinsPublishers‡c2020
+300    ‡aviii, 307 sivua‡c23 cm
+336    ‡atext‡0http://id.loc.gov/vocabulary/contentTypes/txt
+336    ‡ateksti‡0http://id.loc.gov/vocabulary/contentTypes/txt
+337    ‡akäytettävissä ilman laitetta‡0http://id.loc.gov/vocabulary/mediaTypes/n
+338    ‡anide‡0http://id.loc.gov/vocabulary/carriers/nc
+500    ‡akuvitettu, karttoja
+520    ‡aWhisked away from his comfortable, unambitious life in his hobbit-hole in Bag End by Gandalf the wizard and a band of dwarves, Bilbo Baggins finds himself caught up in a plot to raid the treasure hoard of Smaug the Magnificent, a large and very dangerous dragon. Although quite reluctant to take part in this quest, Bilbo surprises even himself by his resourcefulness and his skill as a burglar. The text of this edition has been fully corrected and revised in collaboration with Christopher Tolkien and is accompanied by a wealth of beautiful watercolour paintings and delicate pencil drawings from Alan Lee.
+546    ‡aenglanti.
+600 14 ‡aGandalf (fiktiivinen hahmo)
+600 14 ‡aBaggins, Bilbo (fiktiivinen hahmo)
+650  7 ‡aseikkailu‡0http://www.yso.fi/onto/kauno/p2904‡2kauno/fin
+650  7 ‡amatkat‡0http://www.yso.fi/onto/kauno/p3013‡2kauno/fin
+650  7 ‡aaarteenetsintä‡0http://www.yso.fi/onto/kauno/p4310‡2kauno/fin
+650  7 ‡asormukset‡0http://www.yso.fi/onto/kauno/p3678‡2kauno/fin
+650  7 ‡avelhot‡0http://www.yso.fi/onto/kauno/p4407‡2kauno/fin
+650  7 ‡akääpiöt‡0http://www.yso.fi/onto/kauno/p738‡2kauno/fin
+651  4 ‡aMiddle-earth (fiktiivinen paikka)
+655  7 ‡anovels‡0http://id.loc.gov/authorities/genreForms/gf2015026020‡2lcgft
+655  7 ‡afantasiakirjallisuus‡0http://urn.fi/URN:NBN:fi:au:slm:s1140‡2slm/fin
+655  7 ‡aromaanit‡0http://urn.fi/URN:NBN:fi:au:slm:s518‡2slm/fin
+655  7 ‡akaunokirjallisuus‡0http://urn.fi/URN:NBN:fi:au:slm:s975‡2slm/fin
+655  7 ‡afantasylitteratur‡0http://urn.fi/URN:NBN:fi:au:slm:s1140‡2slm/swe
+655  7 ‡aromaner‡0http://urn.fi/URN:NBN:fi:au:slm:s518‡2slm/swe
+655  7 ‡askönlitteratur‡0http://urn.fi/URN:NBN:fi:au:slm:s975‡2slm/swe
+700 1  ‡aLee, Alan‡ekuvittaja
+884    ‡aDLC bibframe2marc v1.1.0-SNAPSHOT‡g20211123170406.0‡qDLC‡uhttps://github.com/lcnetdev/bibframe2marc


### PR DESCRIPTION
- Update reader to be able to read marcxml that uses a namespace prefix
-- namespace prefix defaults to none, but can be given as third parameter to reader (fe. 'marc:')